### PR TITLE
Fixing error popup "not able to load object details"

### DIFF
--- a/Ginger/Ginger/App.xaml.cs
+++ b/Ginger/Ginger/App.xaml.cs
@@ -270,13 +270,6 @@ namespace Ginger
             }
         }
 
-        public static List<Page> PageList { get; set; }
-
-        public static Page GetPage(Type PageType)
-        {
-            Page p = (from p1 in PageList where p1.GetType() == PageType select p1).FirstOrDefault();
-            return p;
-        }
 
         //public static string LocalApplicationData
         //{

--- a/Ginger/Ginger/WindowExplorer/Common/ControlActionsPage.xaml.cs
+++ b/Ginger/Ginger/WindowExplorer/Common/ControlActionsPage.xaml.cs
@@ -157,12 +157,16 @@ namespace Ginger.WindowExplorer
 
         private void AddToPageList()
         {
-            ControlActionsPage tempPage = App.PageList.FirstOrDefault(Page => Page is ControlActionsPage) as ControlActionsPage;
-            if (tempPage == null) App.PageList.Add(this);
-            else
+            if (App.PageList != null)
             {
-                App.PageList.Remove(tempPage);
-                App.PageList.Add(this);
+                ControlActionsPage tempPage = App.PageList.FirstOrDefault(Page => Page is ControlActionsPage) as ControlActionsPage;
+                if (tempPage == null) App.PageList.Add(this);
+
+                else
+                {
+                    App.PageList.Remove(tempPage);
+                    App.PageList.Add(this);
+                }
             }
         }
 

--- a/Ginger/Ginger/WindowExplorer/Common/ControlActionsPage.xaml.cs
+++ b/Ginger/Ginger/WindowExplorer/Common/ControlActionsPage.xaml.cs
@@ -62,7 +62,7 @@ namespace Ginger.WindowExplorer
             InitActionsGrid();
             InitLocatorsGrid();
             InitDataPage();
-            AddToPageList();            
+             
             SelectLocatorButton.Visibility = System.Windows.Visibility.Collapsed;
         }
 
@@ -106,7 +106,6 @@ namespace Ginger.WindowExplorer
             AddActionButton.Visibility = System.Windows.Visibility.Collapsed;
 
             InitLocatorsGrid();
-            AddToPageList();
         }
 
         private void InitLocatorsGrid()
@@ -155,20 +154,20 @@ namespace Ginger.WindowExplorer
             AvailableControlActionsGrid.SetTitleStyle((Style)TryFindResource("@ucTitleStyle_4"));
         }
 
-        private void AddToPageList()
-        {
-            if (App.PageList != null)
-            {
-                ControlActionsPage tempPage = App.PageList.FirstOrDefault(Page => Page is ControlActionsPage) as ControlActionsPage;
-                if (tempPage == null) App.PageList.Add(this);
+//private void AddToPageList()
+        //{
+        //    if (App.PageList != null)
+        //    {
+        //        ControlActionsPage tempPage = App.PageList.FirstOrDefault(Page => Page is ControlActionsPage) as ControlActionsPage;
+        //        if (tempPage == null) App.PageList.Add(this);
 
-                else
-                {
-                    App.PageList.Remove(tempPage);
-                    App.PageList.Add(this);
-                }
-            }
-        }
+        //        else
+        //        {
+        //            App.PageList.Remove(tempPage);
+        //            App.PageList.Add(this);
+        //        }
+        //    }
+        //}
 
         private void AddActionButton_Click(object sender, RoutedEventArgs e)
         {

--- a/Ginger/Ginger/WindowExplorer/Common/ControlActionsPage.xaml.cs
+++ b/Ginger/Ginger/WindowExplorer/Common/ControlActionsPage.xaml.cs
@@ -154,20 +154,6 @@ namespace Ginger.WindowExplorer
             AvailableControlActionsGrid.SetTitleStyle((Style)TryFindResource("@ucTitleStyle_4"));
         }
 
-//private void AddToPageList()
-        //{
-        //    if (App.PageList != null)
-        //    {
-        //        ControlActionsPage tempPage = App.PageList.FirstOrDefault(Page => Page is ControlActionsPage) as ControlActionsPage;
-        //        if (tempPage == null) App.PageList.Add(this);
-
-        //        else
-        //        {
-        //            App.PageList.Remove(tempPage);
-        //            App.PageList.Add(this);
-        //        }
-        //    }
-        //}
 
         private void AddActionButton_Click(object sender, RoutedEventArgs e)
         {


### PR DESCRIPTION
BugFix-6444-Fixing error popup "not able to load object details"