### PR TITLE
Change default ActionTimeout For WindowDriver to 30+ Handle old xmls …

### DIFF
--- a/Ginger/GingerCore/Drivers/WindowsLib/WindowsDriver.cs
+++ b/Ginger/GingerCore/Drivers/WindowsLib/WindowsDriver.cs
@@ -39,8 +39,8 @@ namespace GingerCore.Drivers.WindowsLib
         int mActionTimeout = 10;
 
         [UserConfigured]
-        [UserConfiguredDefault("10")]  // Local host 
-        [UserConfiguredDescription("Action Timeout - default is 10 seconds")]
+        [UserConfiguredDefault("30")] 
+        [UserConfiguredDescription("Action Timeout - default is 30 seconds")]
         public override int ActionTimeout
         {
             get

--- a/Ginger/GingerCoreNET/RunLib/Agent.cs
+++ b/Ginger/GingerCoreNET/RunLib/Agent.cs
@@ -1023,5 +1023,21 @@ namespace GingerCore
             }
         }
 
+        public override void PostSerialization()
+        {
+
+            if(DriverType == eDriverType.WindowsAutomation)
+            {
+                //Upgrading Action timeout for windows driver from default 10 secs to 30 secs
+                DriverConfigParam actionTimeoutParameter = DriverConfiguration.Where(x => x.Parameter == nameof(DriverBase.ActionTimeout)).FirstOrDefault();
+
+                if (actionTimeoutParameter!=null && actionTimeoutParameter.Value== "10" && actionTimeoutParameter.Description.Contains("10"))
+                {
+                    actionTimeoutParameter.Value = "30";
+                    actionTimeoutParameter.Description=actionTimeoutParameter.Description.Replace("10", "30");
+                }
+            }          
+        }
+
     }
 }

--- a/Ginger/GingerCoreNETUnitTest/GingerCoreNETUnitTest.csproj
+++ b/Ginger/GingerCoreNETUnitTest/GingerCoreNETUnitTest.csproj
@@ -249,6 +249,9 @@
     <None Update="TestResources\Reports\PassedAction.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="TestResources\Repository\Windows.Ginger.Agent.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TestResources\Solutions\AnalyzerTestSolution\Agents\Amdo CSP - Agent 1.Ginger.Agent.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Ginger/GingerCoreNETUnitTest/SolutionTestsLib/RepositorySerializerPrePostTest.cs
+++ b/Ginger/GingerCoreNETUnitTest/SolutionTestsLib/RepositorySerializerPrePostTest.cs
@@ -18,10 +18,13 @@ limitations under the License.
 
 using amdocs.ginger.GingerCoreNET;
 using Amdocs.Ginger.Repository;
+using GingerCore;
+using GingerCore.Drivers;
 using GingerCoreNETUnitTest.RunTestslib;
 using GingerTestHelper;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
+using System.Linq;
 
 namespace GingerCoreNETUnitTests.SolutionTestsLib
 {
@@ -41,6 +44,7 @@ namespace GingerCoreNETUnitTests.SolutionTestsLib
             WorkSpace.Instance.InitWorkspace(new GingerUnitTestWorkspaceReporter(), new UnitTestRepositoryItemFactory());
 
             NewRepositorySerializer.AddClass(typeof(DummyAction).Name, typeof(DummyAction));
+          
         }
 
         [TestCleanup]
@@ -156,7 +160,21 @@ namespace GingerCoreNETUnitTests.SolutionTestsLib
             Assert.AreEqual(7, dummyAction.Age, "Age = 7");
         }
 
+        [TestMethod]
+        public void WindoowsDriverDefaultActionTimeoutUpgradeTest()
+        {
+            //Arrange
+            string fileName = TestResources.GetTestResourcesFile(@"Repository" + Path.DirectorySeparatorChar + "Windows.Ginger.Agent.xml");
 
+            //Act
+            Agent windowsAgent = (Agent)RS.DeserializeFromFile(fileName);
+
+            DriverConfigParam actionTimeoutParameter = windowsAgent.DriverConfiguration.Where(x => x.Parameter == nameof(DriverBase.ActionTimeout)).FirstOrDefault();
+
+            //Assert
+            Assert.AreEqual("30", actionTimeoutParameter.Value, "ActionTimeout = 30");
+            Assert.AreEqual("Action Timeout - default is 30 seconds", actionTimeoutParameter.Description, "ActionTimeout Description Validation");
+        }
 
 
 

--- a/Ginger/GingerCoreNETUnitTest/TestResources/Repository/Windows.Ginger.Agent.xml
+++ b/Ginger/GingerCoreNETUnitTest/TestResources/Repository/Windows.Ginger.Agent.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<GingerRepositoryItem><Header ItemGuid="b0b1f8ad-e8f5-4bf0-8560-979d6e02a75f" ItemType="Agent" CreatedBy="JGHODKE" Created="201907091128" GingerVersion="3.2.0.0" Version="1" LastUpdateBy="JGHODKE" LastUpdate="201907091128" />
+<Agent Active="True" AgentType="Driver" DriverType="WindowsAutomation" Guid="b0b1f8ad-e8f5-4bf0-8560-979d6e02a75f" Name="Windows-Agent" Notes="SolutionExplorerPage.eRefre\" ParentGuid="00000000-0000-0000-0000-000000000000" Platform="Windows">
+<DriverConfiguration>
+<DriverConfigParam Description="Action Timeout - default is 10 seconds" Guid="6b30cfe1-dbc5-4210-91e8-28852327d8bc" Parameter="ActionTimeout" ParentGuid="00000000-0000-0000-0000-000000000000" Value="10" />
+<DriverConfigParam Description="The amount of maximum time (in seconds) to wait for the driver to load/connect" Guid="5fbfbbae-6040-4de2-b348-dde28cf69181" Parameter="DriverLoadWaitingTime" ParentGuid="00000000-0000-0000-0000-000000000000" Value="30" />
+</DriverConfiguration>
+</Agent></GingerRepositoryItem>


### PR DESCRIPTION
Change default ActionTimeout For WindowDriver to 30+ Handle old xmls using post de-serialize