### PR TITLE
Updated Report items Execution/Pass Rates calculation

### DIFF
--- a/Ginger/Ginger/Reports/HTMLReportTemplatePage.xaml
+++ b/Ginger/Ginger/Reports/HTMLReportTemplatePage.xaml
@@ -111,6 +111,15 @@
                                         <RadioButton x:Name="htmlShowFirstIterationOnRadioBtn" Content="Yes" Padding="5,0,0,0" Checked="htmlShowFirstIterationOnRadioBtn_Checked" Style="{StaticResource @InputRadioButtonStyle}"/>
                                     </StackPanel>
                                 </StackPanel>
+                                <StackPanel x:Name="htmlExecutionCalculationLevel" Margin="10,10,0,0" Orientation="Horizontal" ToolTip="Show all iterations execution results on HTML Report e.g. Flow control or retry mechanism iterations">
+                                    <Label Content="Execution/Pass Rate Calculation Level:" Style="{StaticResource @LabelStyle}" FontWeight="Bold" FontSize="12"/>
+                                    <StackPanel x:Name="htmlExecutionCalculationLevelBtnsPnl" Margin="10,0,0,0" Grid.Row="0" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <RadioButton x:Name="htmlExecutionCalculationLevelActivityRadioBtn" Tag="Activity" Content="Activity" Padding="5,0,15,0" Checked="htmlExecutionCalculationLevelActivityRadioBtn_Checked" Style="{StaticResource @InputRadioButtonStyle}"/>
+                                        <RadioButton x:Name="htmlExecutionCalculationLevelActionRadioBtn" Tag="Action" Content="Action" Padding="5,0,0,0" Checked="htmlExecutionCalculationLevelActionRadioBtn_Checked" Style="{StaticResource @InputRadioButtonStyle}"/>
+                                    </StackPanel>
+                                </StackPanel>
+                                <Label Style="{StaticResource @LabelStyle}" FontSize="10" Content="Note: Supported only in case of DB execution logger type is selected." Padding="15,0,0,0"/>
+
                                 <StackPanel x:Name="htmlReportConfigurationPnl" Margin="10,10,0,0" Orientation="Vertical">
                                     <Label Content="HTML Report Configuration By Levels:" Style="{StaticResource @LabelStyle}" FontWeight="Bold" FontSize="12"/>
                                     <StackPanel x:Name="htmlReportConfigSummaryViewFieldsPnl"  Orientation="Horizontal">

--- a/Ginger/Ginger/Reports/HTMLReportTemplatePage.xaml
+++ b/Ginger/Ginger/Reports/HTMLReportTemplatePage.xaml
@@ -111,14 +111,14 @@
                                         <RadioButton x:Name="htmlShowFirstIterationOnRadioBtn" Content="Yes" Padding="5,0,0,0" Checked="htmlShowFirstIterationOnRadioBtn_Checked" Style="{StaticResource @InputRadioButtonStyle}"/>
                                     </StackPanel>
                                 </StackPanel>
-                                <StackPanel x:Name="htmlExecutionCalculationLevel" Margin="10,10,0,0" Orientation="Horizontal" ToolTip="Show all iterations execution results on HTML Report e.g. Flow control or retry mechanism iterations">
+                                <StackPanel x:Name="xExecutionCalculationLevelPnl" Margin="10,10,0,0" Orientation="Horizontal" ToolTip="Show all iterations execution results on HTML Report e.g. Flow control or retry mechanism iterations">
                                     <Label Content="Execution/Pass Rate Calculation Level:" Style="{StaticResource @LabelStyle}" FontWeight="Bold" FontSize="12"/>
-                                    <StackPanel x:Name="htmlExecutionCalculationLevelBtnsPnl" Margin="10,0,0,0" Grid.Row="0" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                        <RadioButton x:Name="htmlExecutionCalculationLevelActivityRadioBtn" Tag="Activity" Content="Activity" Padding="5,0,15,0" Checked="htmlExecutionCalculationLevelActivityRadioBtn_Checked" Style="{StaticResource @InputRadioButtonStyle}"/>
-                                        <RadioButton x:Name="htmlExecutionCalculationLevelActionRadioBtn" Tag="Action" Content="Action" Padding="5,0,0,0" Checked="htmlExecutionCalculationLevelActionRadioBtn_Checked" Style="{StaticResource @InputRadioButtonStyle}"/>
+                                    <StackPanel x:Name="xExecutionCalculationLevelBtnsPnl" Margin="10,0,0,0" Grid.Row="0" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <RadioButton x:Name="xExecutionCalculationLevelActivityRadioBtn" Tag="Activity" Content="Activity" Padding="5,0,15,0" Checked="htmlExecutionCalculationLevelActivityRadioBtn_Checked" Style="{StaticResource @InputRadioButtonStyle}"/>
+                                        <RadioButton x:Name="xExecutionCalculationLevelActionRadioBtn" Tag="Action" Content="Action" Padding="5,0,0,0" Checked="htmlExecutionCalculationLevelActionRadioBtn_Checked" Style="{StaticResource @InputRadioButtonStyle}"/>
                                     </StackPanel>
                                 </StackPanel>
-                                <Label Style="{StaticResource @LabelStyle}" FontSize="10" Content="Note: Supported only in case of DB execution logger type is selected." Padding="15,0,0,0"/>
+                                <Label Style="{StaticResource @LabelStyle}" FontSize="10" Content="Note: Supported only in case the selected Execution Logger type is DB." Padding="15,0,0,0"/>
 
                                 <StackPanel x:Name="htmlReportConfigurationPnl" Margin="10,10,0,0" Orientation="Vertical">
                                     <Label Content="HTML Report Configuration By Levels:" Style="{StaticResource @LabelStyle}" FontWeight="Bold" FontSize="12"/>

--- a/Ginger/Ginger/Reports/HTMLReportTemplatePage.xaml
+++ b/Ginger/Ginger/Reports/HTMLReportTemplatePage.xaml
@@ -114,8 +114,16 @@
                                 <StackPanel x:Name="xExecutionCalculationLevelPnl" Margin="10,10,0,0" Orientation="Horizontal" ToolTip="Show all iterations execution results on HTML Report e.g. Flow control or retry mechanism iterations">
                                     <Label Content="Execution/Pass Rate Calculation Level:" Style="{StaticResource @LabelStyle}" FontWeight="Bold" FontSize="12"/>
                                     <StackPanel x:Name="xExecutionCalculationLevelBtnsPnl" Margin="10,0,0,0" Grid.Row="0" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                        <RadioButton x:Name="xExecutionCalculationLevelActivityRadioBtn" Tag="Activity" Content="Activity" Padding="5,0,15,0" Checked="htmlExecutionCalculationLevelActivityRadioBtn_Checked" Style="{StaticResource @InputRadioButtonStyle}"/>
-                                        <RadioButton x:Name="xExecutionCalculationLevelActionRadioBtn" Tag="Action" Content="Action" Padding="5,0,0,0" Checked="htmlExecutionCalculationLevelActionRadioBtn_Checked" Style="{StaticResource @InputRadioButtonStyle}"/>
+                                        <RadioButton x:Name="xExecutionCalculationLevelActivityRadioBtn" Padding="5,0,15,0" Checked="htmlExecutionCalculationLevelActivityRadioBtn_Checked" Style="{StaticResource @InputRadioButtonStyle}">
+                                            <RadioButton.Content>
+                                                <GingerCore:ucTextDicResource Text="Activities"/>
+                                            </RadioButton.Content>
+                                        </RadioButton>
+                                        <RadioButton x:Name="xExecutionCalculationLevelActionRadioBtn" Padding="5,0,0,0" Checked="htmlExecutionCalculationLevelActionRadioBtn_Checked" Style="{StaticResource @InputRadioButtonStyle}">
+                                            <RadioButton.Content>
+                                                <GingerCore:ucTextDicResource Text="Actions"/>
+                                            </RadioButton.Content>
+                                        </RadioButton>
                                     </StackPanel>
                                 </StackPanel>
                                 <Label Style="{StaticResource @LabelStyle}" FontSize="10" Content="Note: Supported only in case the selected Execution Logger type is DB." Padding="15,0,0,0"/>

--- a/Ginger/Ginger/Reports/HTMLReportTemplatePage.xaml.cs
+++ b/Ginger/Ginger/Reports/HTMLReportTemplatePage.xaml.cs
@@ -96,13 +96,14 @@ namespace Ginger.Reports
         }
         public void RadioButtonInit()
         {
-            string currentValue = _HTMLReportConfiguration.ExecutionCalculationLevel;
-            foreach (RadioButton rdb in htmlExecutionCalculationLevelBtnsPnl.Children)
-                if (rdb.Tag.ToString() == currentValue)
-                {
-                    rdb.IsChecked = true;
-                    break;
-                }
+            if (_HTMLReportConfiguration.ExecutionStatisticsCountBy == HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString())
+            {
+                xExecutionCalculationLevelActionRadioBtn.IsChecked = true;
+            }
+            else
+            {
+                xExecutionCalculationLevelActivityRadioBtn.IsChecked = true;
+            }
         }
 
 
@@ -383,12 +384,12 @@ namespace Ginger.Reports
         }
         private void htmlExecutionCalculationLevelActivityRadioBtn_Checked(object sender, RoutedEventArgs e)
         {
-            _HTMLReportConfiguration.ExecutionCalculationLevel = HTMLReportConfiguration.ReportsExecutionCalculationLevel.Activity.ToString();
+            _HTMLReportConfiguration.ExecutionStatisticsCountBy = HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString();
         }
 
         private void htmlExecutionCalculationLevelActionRadioBtn_Checked(object sender, RoutedEventArgs e)
         {
-            _HTMLReportConfiguration.ExecutionCalculationLevel = HTMLReportConfiguration.ReportsExecutionCalculationLevel.Action.ToString();
+            _HTMLReportConfiguration.ExecutionStatisticsCountBy = HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString();
         }
         private void SelectHTMLReportsImageFolderButton_Click(object sender, RoutedEventArgs e)
         {

--- a/Ginger/Ginger/Reports/HTMLReportTemplatePage.xaml.cs
+++ b/Ginger/Ginger/Reports/HTMLReportTemplatePage.xaml.cs
@@ -92,9 +92,19 @@ namespace Ginger.Reports
             SetLoadedLogoImage();
             SetHTMLReportsConfigFieldsGridsView();
             SetHTMLReportsConfigFieldsGridsData(_HTMLReportConfiguration);
+            RadioButtonInit();
+        }
+        public void RadioButtonInit()
+        {
+            string currentValue = _HTMLReportConfiguration.ExecutionCalculationLevel;
+            foreach (RadioButton rdb in htmlExecutionCalculationLevelBtnsPnl.Children)
+                if (rdb.Tag.ToString() == currentValue)
+                {
+                    rdb.IsChecked = true;
+                    break;
+                }
         }
 
-       
 
         private void SetHTMLReportsConfigFieldsGridsView()
         {
@@ -371,7 +381,15 @@ namespace Ginger.Reports
         {
             _HTMLReportConfiguration.ShowAllIterationsElements = false;
         }
+        private void htmlExecutionCalculationLevelActivityRadioBtn_Checked(object sender, RoutedEventArgs e)
+        {
+            _HTMLReportConfiguration.ExecutionCalculationLevel = HTMLReportConfiguration.ReportsExecutionCalculationLevel.Activity.ToString();
+        }
 
+        private void htmlExecutionCalculationLevelActionRadioBtn_Checked(object sender, RoutedEventArgs e)
+        {
+            _HTMLReportConfiguration.ExecutionCalculationLevel = HTMLReportConfiguration.ReportsExecutionCalculationLevel.Action.ToString();
+        }
         private void SelectHTMLReportsImageFolderButton_Click(object sender, RoutedEventArgs e)
         {
             System.Windows.Forms.OpenFileDialog op = new System.Windows.Forms.OpenFileDialog();

--- a/Ginger/Ginger/Reports/HTMLReportTemplatePage.xaml.cs
+++ b/Ginger/Ginger/Reports/HTMLReportTemplatePage.xaml.cs
@@ -96,7 +96,7 @@ namespace Ginger.Reports
         }
         public void RadioButtonInit()
         {
-            if (_HTMLReportConfiguration.ExecutionStatisticsCountBy == HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString())
+            if (_HTMLReportConfiguration.ExecutionStatisticsCountBy == HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions)
             {
                 xExecutionCalculationLevelActionRadioBtn.IsChecked = true;
             }
@@ -384,12 +384,12 @@ namespace Ginger.Reports
         }
         private void htmlExecutionCalculationLevelActivityRadioBtn_Checked(object sender, RoutedEventArgs e)
         {
-            _HTMLReportConfiguration.ExecutionStatisticsCountBy = HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString();
+            _HTMLReportConfiguration.ExecutionStatisticsCountBy = HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities;
         }
 
         private void htmlExecutionCalculationLevelActionRadioBtn_Checked(object sender, RoutedEventArgs e)
         {
-            _HTMLReportConfiguration.ExecutionStatisticsCountBy = HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString();
+            _HTMLReportConfiguration.ExecutionStatisticsCountBy = HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions;
         }
         private void SelectHTMLReportsImageFolderButton_Click(object sender, RoutedEventArgs e)
         {

--- a/Ginger/GingerCoreNET/LiteDBFolder/LiteDbReportBase.cs
+++ b/Ginger/GingerCoreNET/LiteDBFolder/LiteDbReportBase.cs
@@ -232,9 +232,6 @@ namespace Amdocs.Ginger.CoreNET.LiteDBFolder
         public LiteDbActivity()
         {
             ActionsColl = new List<LiteDbAction>();
-            //ChildExecutableItemsCount = new Dictionary<string, int>();
-            //ChildExecutedItemsCount = new Dictionary<string, int>();
-            //ChildPassedItemsCount = new Dictionary<string, int>();
         }
 
         public void SetReportData(ActivityReport activityReport)

--- a/Ginger/GingerCoreNET/LiteDBFolder/LiteDbReportBase.cs
+++ b/Ginger/GingerCoreNET/LiteDBFolder/LiteDbReportBase.cs
@@ -47,8 +47,8 @@ namespace Amdocs.Ginger.CoreNET.LiteDBFolder
         public List<string> VariablesAfterExec { get; set; }
         public LiteDB.ObjectId _id { get; set; }
 
-        public string ExecutionRate { get; set; }
-        public string PassRate { get; set; }
+        public string ExecutionRate { get; set; } = "0";
+        public string PassRate { get; set; } = "0";
 
         public LiteDbReportBase()
         {
@@ -97,9 +97,15 @@ namespace Amdocs.Ginger.CoreNET.LiteDBFolder
         public string MachineName { get; set; }
         public string ExecutedbyUser { get; set; }
         public List<LiteDbRunner> RunnersColl { get; set; }
+        public Dictionary<string, int> ChildExecutableItemsCount { get; set; }
+        public Dictionary<string, int> ChildExecutedItemsCount { get; set; }
+        public Dictionary<string, int> ChildPassedItemsCount { get; set; }
         public LiteDbRunSet()
         {
             RunnersColl = new List<LiteDbRunner>();
+            ChildExecutableItemsCount = new Dictionary<string, int>();
+            ChildExecutedItemsCount = new Dictionary<string, int>();
+            ChildPassedItemsCount = new Dictionary<string, int>();
         }
 
         internal void SetReportData(RunSetReport runSetReport)
@@ -122,9 +128,15 @@ namespace Amdocs.Ginger.CoreNET.LiteDBFolder
     {
         public List<string> ApplicationAgentsMappingList { get; set; }
         public List<LiteDbBusinessFlow> BusinessFlowsColl { get; set; }
+        public Dictionary<string, int> ChildExecutableItemsCount { get; set; }
+        public Dictionary<string, int> ChildExecutedItemsCount { get; set; }
+        public Dictionary<string, int> ChildPassedItemsCount { get; set; }
         public LiteDbRunner()
         {
             BusinessFlowsColl = new List<LiteDbBusinessFlow>();
+            ChildExecutableItemsCount = new Dictionary<string, int>();
+            ChildExecutedItemsCount = new Dictionary<string, int>();
+            ChildPassedItemsCount = new Dictionary<string, int>();
         }
 
         internal void SetReportData(GingerReport gingerReport)
@@ -149,10 +161,18 @@ namespace Amdocs.Ginger.CoreNET.LiteDBFolder
         public List<LiteDbActivity> ActivitiesColl { get; set; }
         public List<LiteDbActivityGroup> ActivitiesGroupsColl { get; set; }
         public List<string> BFFlowControlDT { get; set; }
+
+
+        public Dictionary<string, int> ChildExecutableItemsCount { get; set; }
+        public Dictionary<string, int> ChildExecutedItemsCount { get; set; }
+        public Dictionary<string, int> ChildPassedItemsCount { get; set; }
         public LiteDbBusinessFlow()
         {
             ActivitiesGroupsColl = new List<LiteDbActivityGroup>();
             ActivitiesColl = new List<LiteDbActivity>();
+            ChildExecutableItemsCount = new Dictionary<string, int>();
+            ChildExecutedItemsCount = new Dictionary<string, int>();
+            ChildPassedItemsCount = new Dictionary<string, int>();
         }
         public void SetReportData(BusinessFlowReport bfReport)
         {
@@ -205,9 +225,24 @@ namespace Amdocs.Ginger.CoreNET.LiteDBFolder
     {
         public string ActivityGroupName { get; set; }
         public List<LiteDbAction> ActionsColl { get; set; }
+        //public List<Tuple<string, string>> ChildExecutableItemsCount { get; set; }
+        //public List<Tuple<string, string>> ChildExecutedItemsCount { get; set; }
+        //public List<Tuple<string, string>> ChildPassedItemsCount { get; set; }
+
+        public Dictionary<string, int> ChildExecutableItemsCount { get; set; }
+        public Dictionary<string, int> ChildExecutedItemsCount { get; set; }
+        public Dictionary<string, int> ChildPassedItemsCount { get; set; }
+
         public LiteDbActivity()
         {
             ActionsColl = new List<LiteDbAction>();
+            //ChildExecutableItemsCount = new List<Tuple<string, string>>();
+            //ChildExecutedItemsCount = new List<Tuple<string, string>>();
+            //ChildPassedItemsCount = new List<Tuple<string, string>>();
+
+            ChildExecutableItemsCount = new Dictionary<string, int>();
+            ChildExecutedItemsCount = new Dictionary<string, int>();
+            ChildPassedItemsCount = new Dictionary<string, int>();
         }
 
         public void SetReportData(ActivityReport activityReport)

--- a/Ginger/GingerCoreNET/LiteDBFolder/LiteDbReportBase.cs
+++ b/Ginger/GingerCoreNET/LiteDBFolder/LiteDbReportBase.cs
@@ -47,8 +47,8 @@ namespace Amdocs.Ginger.CoreNET.LiteDBFolder
         public List<string> VariablesAfterExec { get; set; }
         public LiteDB.ObjectId _id { get; set; }
 
-        public string ExecutionRate { get; set; } = "0";
-        public string PassRate { get; set; } = "0";
+        public string ExecutionRate { get; set; }
+        public string PassRate { get; set; }
 
         public LiteDbReportBase()
         {
@@ -225,24 +225,16 @@ namespace Amdocs.Ginger.CoreNET.LiteDBFolder
     {
         public string ActivityGroupName { get; set; }
         public List<LiteDbAction> ActionsColl { get; set; }
-        //public List<Tuple<string, string>> ChildExecutableItemsCount { get; set; }
-        //public List<Tuple<string, string>> ChildExecutedItemsCount { get; set; }
-        //public List<Tuple<string, string>> ChildPassedItemsCount { get; set; }
-
-        public Dictionary<string, int> ChildExecutableItemsCount { get; set; }
-        public Dictionary<string, int> ChildExecutedItemsCount { get; set; }
-        public Dictionary<string, int> ChildPassedItemsCount { get; set; }
+        public int ChildExecutableItemsCount { get; set; }
+        public int ChildExecutedItemsCount { get; set; }
+        public int ChildPassedItemsCount { get; set; }
 
         public LiteDbActivity()
         {
             ActionsColl = new List<LiteDbAction>();
-            //ChildExecutableItemsCount = new List<Tuple<string, string>>();
-            //ChildExecutedItemsCount = new List<Tuple<string, string>>();
-            //ChildPassedItemsCount = new List<Tuple<string, string>>();
-
-            ChildExecutableItemsCount = new Dictionary<string, int>();
-            ChildExecutedItemsCount = new Dictionary<string, int>();
-            ChildPassedItemsCount = new Dictionary<string, int>();
+            //ChildExecutableItemsCount = new Dictionary<string, int>();
+            //ChildExecutedItemsCount = new Dictionary<string, int>();
+            //ChildPassedItemsCount = new Dictionary<string, int>();
         }
 
         public void SetReportData(ActivityReport activityReport)

--- a/Ginger/GingerCoreNET/Logger/WebReportGenerator.cs
+++ b/Ginger/GingerCoreNET/Logger/WebReportGenerator.cs
@@ -134,24 +134,18 @@ namespace Amdocs.Ginger.CoreNET.Logger
             HTMLReportConfiguration _HTMLReportConfig = WorkSpace.Instance.SolutionRepository.GetAllRepositoryItems<HTMLReportConfiguration>().Where(x => (x.IsDefault == true)).FirstOrDefault();
 
             //populate data based on level
-            if (string.IsNullOrEmpty(_HTMLReportConfig.ExecutionStatisticsCountBy))
+            if (string.IsNullOrEmpty(_HTMLReportConfig.ExecutionStatisticsCountBy.ToString()))
             {
-                _HTMLReportConfig.ExecutionStatisticsCountBy = HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString();
+                _HTMLReportConfig.ExecutionStatisticsCountBy = HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions;
             }
 
             string imageFolderPath = Path.Combine(clientAppPath, "assets", "screenshots");
             List<string> runSetEnv = new List<string>();
 
-            if (liteDbRunSet.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] != 0)
-            {
-                liteDbRunSet.ExecutionRate = string.Format("{0:F1}", (liteDbRunSet.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] * 100 / liteDbRunSet.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy]).ToString());
-            }
-            else { liteDbRunSet.ExecutionRate = "0"; }
-            if (liteDbRunSet.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] != 0)
-            {
-                liteDbRunSet.PassRate = string.Format("{0:F1}", (liteDbRunSet.ChildPassedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] * 100 / liteDbRunSet.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy]).ToString());
-            }
-            else { liteDbRunSet.PassRate = "0"; }
+            liteDbRunSet.ExecutionRate = string.Format("{0:F1}", CalculateExecutionOrPassRate(liteDbRunSet.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy.ToString()], liteDbRunSet.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy.ToString()]));
+
+            liteDbRunSet.PassRate = string.Format("{0:F1}", CalculateExecutionOrPassRate(liteDbRunSet.ChildPassedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy.ToString()], liteDbRunSet.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy.ToString()]));
+
             if (liteDbRunSet.Elapsed.HasValue)
             {
                 liteDbRunSet.Elapsed = Math.Round(liteDbRunSet.Elapsed.Value, 2);
@@ -162,48 +156,36 @@ namespace Amdocs.Ginger.CoreNET.Logger
                 {
                     runSetEnv.Add(liteDbRunner.Environment);
                 }
-                if (liteDbRunner.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] != 0)
-                {
-                    liteDbRunner.ExecutionRate = string.Format("{0:F1}", (liteDbRunner.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] * 100 / liteDbRunner.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy]).ToString());
-                }
-                else { liteDbRunner.ExecutionRate = "0"; }
-                if (liteDbRunner.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] != 0)
-                {
-                    liteDbRunner.PassRate = string.Format("{0:F1}", (liteDbRunner.ChildPassedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] * 100 / liteDbRunner.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy]).ToString());
-                }
-                else { liteDbRunner.PassRate = "0"; }
+                
+                liteDbRunner.ExecutionRate = string.Format("{0:F1}", CalculateExecutionOrPassRate(liteDbRunner.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy.ToString()], liteDbRunner.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy.ToString()]));
+
+                liteDbRunner.PassRate = string.Format("{0:F1}", CalculateExecutionOrPassRate(liteDbRunner.ChildPassedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy.ToString()], liteDbRunner.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy.ToString()]));
+
                 if (liteDbRunner.Elapsed.HasValue)
                 {
                     liteDbRunner.Elapsed = Math.Round(liteDbRunner.Elapsed.Value, 2);
                 }
+                else { liteDbRunner.Elapsed = 0; }
                 foreach (LiteDbBusinessFlow liteDbBusinessFlow in liteDbRunner.BusinessFlowsColl)
                 {
-                    if (liteDbBusinessFlow.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] != 0)
-                    {
-                        liteDbBusinessFlow.ExecutionRate = string.Format("{0:F1}", (liteDbBusinessFlow.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] * 100 / liteDbBusinessFlow.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy]).ToString());
-                    }
-                    else { liteDbBusinessFlow.PassRate = "0"; }
-                    if (liteDbBusinessFlow.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] != 0)
-                    {
-                        liteDbBusinessFlow.PassRate = string.Format("{0:F1}", (liteDbBusinessFlow.ChildPassedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] * 100 / liteDbBusinessFlow.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy]).ToString());
-                    }
-                    else { liteDbBusinessFlow.PassRate = "0"; }
+                   
+                    liteDbBusinessFlow.ExecutionRate = string.Format("{0:F1}", CalculateExecutionOrPassRate(liteDbBusinessFlow.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy.ToString()], liteDbBusinessFlow.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy.ToString()]));
+
+                    liteDbBusinessFlow.PassRate = string.Format("{0:F1}", CalculateExecutionOrPassRate(liteDbBusinessFlow.ChildPassedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy.ToString()], liteDbBusinessFlow.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy.ToString()]));
+
                     if (liteDbBusinessFlow.Elapsed.HasValue)
                     {
                         liteDbBusinessFlow.Elapsed = Math.Round(liteDbBusinessFlow.Elapsed.Value, 2);
                     }
+                    else { liteDbBusinessFlow.Elapsed = 0; }
                     foreach (LiteDbActivity liteDbActivity in liteDbBusinessFlow.ActivitiesColl)
                     {
-                        if (liteDbActivity.ChildExecutableItemsCount != 0)
-                        {
-                            liteDbActivity.ExecutionRate = string.Format("{0:F1}", (liteDbActivity.ChildExecutedItemsCount * 100 / liteDbActivity.ChildExecutableItemsCount).ToString());
-                        }
-                        else { liteDbActivity.PassRate = "0"; }
-                        if (liteDbActivity.ChildExecutedItemsCount != 0)
-                        {
-                            liteDbActivity.PassRate = string.Format("{0:F1}", (liteDbActivity.ChildPassedItemsCount * 100 / liteDbActivity.ChildExecutedItemsCount).ToString());
-                        }
-                        else { liteDbActivity.PassRate = "0"; }
+                        
+                        liteDbActivity.ExecutionRate = string.Format("{0:F1}", CalculateExecutionOrPassRate(liteDbActivity.ChildExecutedItemsCount, liteDbActivity.ChildExecutableItemsCount));
+
+                        liteDbActivity.PassRate = string.Format("{0:F1}", CalculateExecutionOrPassRate(liteDbActivity.ChildPassedItemsCount, liteDbActivity.ChildExecutedItemsCount));
+
+                        
                         if (liteDbActivity.Elapsed.HasValue)
                         {
                             liteDbActivity.Elapsed = Math.Round(liteDbActivity.Elapsed.Value / 1000, 4);
@@ -238,6 +220,17 @@ namespace Amdocs.Ginger.CoreNET.Logger
             if (runSetEnv.Count > 0)
             {
                 liteDbRunSet.Environment = string.Join(",", runSetEnv);
+            }
+        }
+        private string CalculateExecutionOrPassRate(int firstItem, int secondItem)
+        {
+            if (secondItem != 0)
+            {
+                return (firstItem * 100 / secondItem).ToString();
+            }
+            else
+            {
+                return "0";
             }
         }
 

--- a/Ginger/GingerCoreNET/Logger/WebReportGenerator.cs
+++ b/Ginger/GingerCoreNET/Logger/WebReportGenerator.cs
@@ -134,51 +134,89 @@ namespace Amdocs.Ginger.CoreNET.Logger
             HTMLReportConfiguration _HTMLReportConfig = WorkSpace.Instance.SolutionRepository.GetAllRepositoryItems<HTMLReportConfiguration>().Where(x => (x.IsDefault == true)).FirstOrDefault();
 
             //populate data based on level
-            if (string.IsNullOrEmpty(_HTMLReportConfig.ExecutionCalculationLevel))
+            if (string.IsNullOrEmpty(_HTMLReportConfig.ExecutionStatisticsCountBy))
             {
-                _HTMLReportConfig.ExecutionCalculationLevel = HTMLReportConfiguration.ReportsExecutionCalculationLevel.Activity.ToString();
+                _HTMLReportConfig.ExecutionStatisticsCountBy = HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString();
             }
 
             string imageFolderPath = Path.Combine(clientAppPath, "assets", "screenshots");
             List<string> runSetEnv = new List<string>();
 
-            if (liteDbRunSet.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] != 0)
-                liteDbRunSet.ExecutionRate = string.Format("{0:F1}", (liteDbRunSet.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] * 100 / liteDbRunSet.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionCalculationLevel]).ToString());
-            if (liteDbRunSet.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] != 0)
-                liteDbRunSet.PassRate = string.Format("{0:F1}", (liteDbRunSet.ChildPassedItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] * 100 / liteDbRunSet.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionCalculationLevel]).ToString());
+            if (liteDbRunSet.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] != 0)
+            {
+                liteDbRunSet.ExecutionRate = string.Format("{0:F1}", (liteDbRunSet.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] * 100 / liteDbRunSet.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy]).ToString());
+            }
+            else { liteDbRunSet.ExecutionRate = "0"; }
+            if (liteDbRunSet.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] != 0)
+            {
+                liteDbRunSet.PassRate = string.Format("{0:F1}", (liteDbRunSet.ChildPassedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] * 100 / liteDbRunSet.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy]).ToString());
+            }
+            else { liteDbRunSet.PassRate = "0"; }
+            if (liteDbRunSet.Elapsed.HasValue)
+            {
+                liteDbRunSet.Elapsed = Math.Round(liteDbRunSet.Elapsed.Value, 2);
+            }
             foreach (LiteDbRunner liteDbRunner in liteDbRunSet.RunnersColl)
             {
                 if (!runSetEnv.Contains(liteDbRunner.Environment))
                 {
                     runSetEnv.Add(liteDbRunner.Environment);
                 }
-                if (liteDbRunner.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] != 0)
-                    liteDbRunner.ExecutionRate = string.Format("{0:F1}", (liteDbRunner.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] * 100 / liteDbRunner.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionCalculationLevel]).ToString());
-                if (liteDbRunner.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] != 0)
-                    liteDbRunner.PassRate = string.Format("{0:F1}", (liteDbRunner.ChildPassedItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] * 100 / liteDbRunner.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionCalculationLevel]).ToString());
+                if (liteDbRunner.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] != 0)
+                {
+                    liteDbRunner.ExecutionRate = string.Format("{0:F1}", (liteDbRunner.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] * 100 / liteDbRunner.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy]).ToString());
+                }
+                else { liteDbRunner.ExecutionRate = "0"; }
+                if (liteDbRunner.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] != 0)
+                {
+                    liteDbRunner.PassRate = string.Format("{0:F1}", (liteDbRunner.ChildPassedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] * 100 / liteDbRunner.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy]).ToString());
+                }
+                else { liteDbRunner.PassRate = "0"; }
                 if (liteDbRunner.Elapsed.HasValue)
+                {
                     liteDbRunner.Elapsed = Math.Round(liteDbRunner.Elapsed.Value, 2);
+                }
                 foreach (LiteDbBusinessFlow liteDbBusinessFlow in liteDbRunner.BusinessFlowsColl)
                 {
-                    if (liteDbBusinessFlow.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] != 0)
-                        liteDbBusinessFlow.ExecutionRate = string.Format("{0:F1}", (liteDbBusinessFlow.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] * 100 / liteDbBusinessFlow.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionCalculationLevel]).ToString());
-                    if (liteDbBusinessFlow.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] != 0)
-                        liteDbBusinessFlow.PassRate = string.Format("{0:F1}", (liteDbBusinessFlow.ChildPassedItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] * 100 / liteDbBusinessFlow.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionCalculationLevel]).ToString());
+                    if (liteDbBusinessFlow.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] != 0)
+                    {
+                        liteDbBusinessFlow.ExecutionRate = string.Format("{0:F1}", (liteDbBusinessFlow.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] * 100 / liteDbBusinessFlow.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy]).ToString());
+                    }
+                    else { liteDbBusinessFlow.PassRate = "0"; }
+                    if (liteDbBusinessFlow.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] != 0)
+                    {
+                        liteDbBusinessFlow.PassRate = string.Format("{0:F1}", (liteDbBusinessFlow.ChildPassedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy] * 100 / liteDbBusinessFlow.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionStatisticsCountBy]).ToString());
+                    }
+                    else { liteDbBusinessFlow.PassRate = "0"; }
                     if (liteDbBusinessFlow.Elapsed.HasValue)
+                    {
                         liteDbBusinessFlow.Elapsed = Math.Round(liteDbBusinessFlow.Elapsed.Value, 2);
+                    }
                     foreach (LiteDbActivity liteDbActivity in liteDbBusinessFlow.ActivitiesColl)
                     {
-                        if (liteDbActivity.ChildExecutableItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] != 0)
-                            liteDbActivity.ExecutionRate = string.Format("{0:F1}", (liteDbActivity.ChildExecutedItemsCount[HTMLReportConfiguration.ReportsExecutionCalculationLevel.Action.ToString()] * 100 / liteDbActivity.ChildExecutableItemsCount[HTMLReportConfiguration.ReportsExecutionCalculationLevel.Action.ToString()]).ToString());
-                        if (liteDbActivity.ChildExecutedItemsCount[_HTMLReportConfig.ExecutionCalculationLevel] != 0)
-                            liteDbActivity.PassRate = string.Format("{0:F1}", (liteDbActivity.ChildPassedItemsCount[HTMLReportConfiguration.ReportsExecutionCalculationLevel.Action.ToString()] * 100 / liteDbActivity.ChildExecutedItemsCount[HTMLReportConfiguration.ReportsExecutionCalculationLevel.Action.ToString()]).ToString());
+                        if (liteDbActivity.ChildExecutableItemsCount != 0)
+                        {
+                            liteDbActivity.ExecutionRate = string.Format("{0:F1}", (liteDbActivity.ChildExecutedItemsCount * 100 / liteDbActivity.ChildExecutableItemsCount).ToString());
+                        }
+                        else { liteDbActivity.PassRate = "0"; }
+                        if (liteDbActivity.ChildExecutedItemsCount != 0)
+                        {
+                            liteDbActivity.PassRate = string.Format("{0:F1}", (liteDbActivity.ChildPassedItemsCount * 100 / liteDbActivity.ChildExecutedItemsCount).ToString());
+                        }
+                        else { liteDbActivity.PassRate = "0"; }
                         if (liteDbActivity.Elapsed.HasValue)
+                        {
                             liteDbActivity.Elapsed = Math.Round(liteDbActivity.Elapsed.Value / 1000, 4);
+                        }
+                        else { liteDbActivity.Elapsed = 0; }
                         foreach (LiteDbAction liteDbAction in liteDbActivity.ActionsColl)
                         {
                             List<string> newScreenShotsList = new List<string>();
                             if (liteDbAction.Elapsed.HasValue)
+                            {
                                 liteDbAction.Elapsed = Math.Round(liteDbAction.Elapsed.Value / 1000, 4);
+                            }
+                            else { liteDbAction.Elapsed = 0; }
                             if ((!string.IsNullOrEmpty(liteDbAction.ExInfo)) && liteDbAction.ExInfo[liteDbAction.ExInfo.Length - 1] == '-')
                                 liteDbAction.ExInfo = liteDbAction.ExInfo.Remove(liteDbAction.ExInfo.Length - 1);
                             foreach (string screenshot in liteDbAction.ScreenShots)

--- a/Ginger/GingerCoreNET/Reports/BusinessFlowReport.cs
+++ b/Ginger/GingerCoreNET/Reports/BusinessFlowReport.cs
@@ -394,7 +394,7 @@ namespace Ginger.Reports
         public double ExecutionRate { get { return Activities.Count != 0 ? Math.Round((double)(TotalActivities - TotalActivitiesOther) * 100 / TotalActivities, MidpointRounding.AwayFromZero)  : 0; } }
 
         [FieldParams]
-        [FieldParamsNameCaption("Business Flow Activities Passed Rate")]
+        [FieldParamsNameCaption("Business Flow Passed Rate")]
         [FieldParamsFieldType(FieldsType.Field)]
         [FieldParamsIsNotMandatory(true)]
         [FieldParamsIsSelected(true)]

--- a/Ginger/GingerCoreNET/Reports/BusinessFlowReport.cs
+++ b/Ginger/GingerCoreNET/Reports/BusinessFlowReport.cs
@@ -386,7 +386,7 @@ namespace Ginger.Reports
         }
 
         [FieldParams]
-        [FieldParamsNameCaption("Business Flow Activities Execution Rate")]
+        [FieldParamsNameCaption("Business Flow Execution Rate")]
         [FieldParamsFieldType(FieldsType.Field)]
         [FieldParamsIsNotMandatory(true)]
         [FieldParamsIsSelected(true)]

--- a/Ginger/GingerCoreNET/Reports/BusinessFlowReport.cs
+++ b/Ginger/GingerCoreNET/Reports/BusinessFlowReport.cs
@@ -56,6 +56,7 @@ namespace Ginger.Reports
             public static string Elapsed = "Elapsed";
             public static string RunStatus = "RunStatus";
             public static string NumberOfActivities = "NumberOfActivities";
+            public static string ExecutionRate = "ExecutionRate";
             public static string PassPercent = "PassPercent";
             public static string VariablesDetails = "VariablesDetails";
             public static string ActivityDetails = "ActivityDetails";
@@ -383,6 +384,14 @@ namespace Ginger.Reports
                 return count;
             }
         }
+
+        [FieldParams]
+        [FieldParamsNameCaption("Business Flow Activities Execution Rate")]
+        [FieldParamsFieldType(FieldsType.Field)]
+        [FieldParamsIsNotMandatory(true)]
+        [FieldParamsIsSelected(true)]
+
+        public double ExecutionRate { get { return Activities.Count != 0 ? Math.Round((double)(TotalActivities - TotalActivitiesOther) * 100 / TotalActivities, MidpointRounding.AwayFromZero)  : 0; } }
 
         [FieldParams]
         [FieldParamsNameCaption("Business Flow Activities Passed Rate")]

--- a/Ginger/GingerCoreNET/Reports/HTMLReportConfiguration.cs
+++ b/Ginger/GingerCoreNET/Reports/HTMLReportConfiguration.cs
@@ -45,7 +45,8 @@ namespace Ginger.Reports
             public static string BusinessFlowFieldsToSelect = "BusinessFlowFieldsToSelect";
             public static string GingerRunnerFieldsToSelect = "GingerRunnerFieldsToSelect";
             public static string RunSetFieldsToSelect = "RunSetFieldsToSelect";
-            public static string ReportLowerLevelToShow = "ReportLowerLevelToShow";            
+            public static string ReportLowerLevelToShow = "ReportLowerLevelToShow";
+            public static string ExecutionCalculationLevel = "ExecutionCalculationLevel";
         }
 
         bool mIsSelected;
@@ -70,6 +71,10 @@ namespace Ginger.Reports
         bool mShowAllIterationsElements;
         [IsSerializedForLocalRepository]
         public bool ShowAllIterationsElements { get { return mShowAllIterationsElements; } set { if (mShowAllIterationsElements != value) { mShowAllIterationsElements = value; OnPropertyChanged(nameof(ShowAllIterationsElements)); } } }
+
+        string mExecutionCalculationLevel;
+        [IsSerializedForLocalRepository]
+        public string ExecutionCalculationLevel { get { return mExecutionCalculationLevel; } set { if (mExecutionCalculationLevel != value) { mExecutionCalculationLevel = value; OnPropertyChanged(nameof(ExecutionCalculationLevel)); } } }
 
         bool mUseLocalStoredStyling;
         [IsSerializedForLocalRepository]
@@ -114,6 +119,12 @@ namespace Ginger.Reports
             GingerRunnerFieldsToSelect,
             RunSetFieldsToSelect,
             EmailSummaryViewFieldsToSelect
+        }
+
+        public enum ReportsExecutionCalculationLevel
+        {
+            Action,
+            Activity
         }
 
         [IsSerializedForLocalRepository]

--- a/Ginger/GingerCoreNET/Reports/HTMLReportConfiguration.cs
+++ b/Ginger/GingerCoreNET/Reports/HTMLReportConfiguration.cs
@@ -72,9 +72,9 @@ namespace Ginger.Reports
         [IsSerializedForLocalRepository]
         public bool ShowAllIterationsElements { get { return mShowAllIterationsElements; } set { if (mShowAllIterationsElements != value) { mShowAllIterationsElements = value; OnPropertyChanged(nameof(ShowAllIterationsElements)); } } }
 
-        string mExecutionStatisticsCountBy;
+        eExecutionStatisticsCountBy mExecutionStatisticsCountBy;
         [IsSerializedForLocalRepository]
-        public string ExecutionStatisticsCountBy { get { return mExecutionStatisticsCountBy; } set { if (mExecutionStatisticsCountBy != value) { mExecutionStatisticsCountBy = value; OnPropertyChanged(nameof(ExecutionStatisticsCountBy)); } } }
+        public eExecutionStatisticsCountBy ExecutionStatisticsCountBy { get { return mExecutionStatisticsCountBy; } set { if (mExecutionStatisticsCountBy != value) { mExecutionStatisticsCountBy = value; OnPropertyChanged(nameof(ExecutionStatisticsCountBy)); } } }
 
         bool mUseLocalStoredStyling;
         [IsSerializedForLocalRepository]
@@ -123,8 +123,8 @@ namespace Ginger.Reports
 
         public enum eExecutionStatisticsCountBy
         {
-            Action,
-            Activity
+            Actions,
+            Activities
         }
 
         [IsSerializedForLocalRepository]

--- a/Ginger/GingerCoreNET/Reports/HTMLReportConfiguration.cs
+++ b/Ginger/GingerCoreNET/Reports/HTMLReportConfiguration.cs
@@ -46,7 +46,7 @@ namespace Ginger.Reports
             public static string GingerRunnerFieldsToSelect = "GingerRunnerFieldsToSelect";
             public static string RunSetFieldsToSelect = "RunSetFieldsToSelect";
             public static string ReportLowerLevelToShow = "ReportLowerLevelToShow";
-            public static string ExecutionCalculationLevel = "ExecutionCalculationLevel";
+            public static string ExecutionStatisticsCountBy = "ExecutionStatisticsCountBy";
         }
 
         bool mIsSelected;
@@ -72,9 +72,9 @@ namespace Ginger.Reports
         [IsSerializedForLocalRepository]
         public bool ShowAllIterationsElements { get { return mShowAllIterationsElements; } set { if (mShowAllIterationsElements != value) { mShowAllIterationsElements = value; OnPropertyChanged(nameof(ShowAllIterationsElements)); } } }
 
-        string mExecutionCalculationLevel;
+        string mExecutionStatisticsCountBy;
         [IsSerializedForLocalRepository]
-        public string ExecutionCalculationLevel { get { return mExecutionCalculationLevel; } set { if (mExecutionCalculationLevel != value) { mExecutionCalculationLevel = value; OnPropertyChanged(nameof(ExecutionCalculationLevel)); } } }
+        public string ExecutionStatisticsCountBy { get { return mExecutionStatisticsCountBy; } set { if (mExecutionStatisticsCountBy != value) { mExecutionStatisticsCountBy = value; OnPropertyChanged(nameof(ExecutionStatisticsCountBy)); } } }
 
         bool mUseLocalStoredStyling;
         [IsSerializedForLocalRepository]
@@ -121,7 +121,7 @@ namespace Ginger.Reports
             EmailSummaryViewFieldsToSelect
         }
 
-        public enum ReportsExecutionCalculationLevel
+        public enum eExecutionStatisticsCountBy
         {
             Action,
             Activity

--- a/Ginger/GingerCoreNET/Run/RunListenerLib/LiteDBRepository.cs
+++ b/Ginger/GingerCoreNET/Run/RunListenerLib/LiteDBRepository.cs
@@ -158,10 +158,7 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
             }
             activity.Acts.ToList().ForEach(action => this.MapActionToLiteDb((GingerCore.Actions.Act)action, context, executedFrom));
             AR.ActionsColl.AddRange(liteDbActionList);
-            //counts
-            //AR.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), activity.Acts.Count);
-            //AR.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), (activity.Acts.Count - activity.Acts.Count(x => x.Status == eRunStatus.Pending || x.Status == eRunStatus.Skipped || x.Status == eRunStatus.Blocked)));
-            //AR.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), activity.Acts.Count(x => x.Status == eRunStatus.Passed));
+            
             AR.ChildExecutableItemsCount = activity.Acts.Count(x => x.Active == true);
             AR.ChildExecutedItemsCount = AR.ChildExecutableItemsCount - activity.Acts.Count(x => x.Status == eRunStatus.Pending || x.Status == eRunStatus.Skipped || x.Status == eRunStatus.Blocked);
             AR.ChildPassedItemsCount = activity.Acts.Count(x => x.Status == eRunStatus.Passed);
@@ -229,9 +226,9 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
             ChildExecutedItemsCountActivity = ChildExecutableItemsCountActivity - context.BusinessFlow.Activities.Where(ac => ac.Status == eRunStatus.Pending || ac.Status == eRunStatus.Skipped || ac.Status == eRunStatus.Blocked).Count();
             ChildPassedItemsCountActivity = context.BusinessFlow.Activities.Where(ac => ac.Status == eRunStatus.Passed).Count();
 
-            BFR.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildExecutableItemsCountActivity);
-            BFR.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildExecutedItemsCountActivity);
-            BFR.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildPassedItemsCountActivity);
+            BFR.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), ChildExecutableItemsCountActivity);
+            BFR.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), ChildExecutedItemsCountActivity);
+            BFR.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), ChildPassedItemsCountActivity);
 
             int ChildExecutableItemsCountAction = 0;
             int ChildExecutedItemsCountAction = 0;
@@ -242,9 +239,9 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
                 ChildExecutedItemsCountAction = ChildExecutedItemsCountAction + activity.ChildExecutedItemsCount;
                 ChildPassedItemsCountAction = ChildPassedItemsCountAction + activity.ChildPassedItemsCount;
             }
-            BFR.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildExecutableItemsCountAction);
-            BFR.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildExecutedItemsCountAction);
-            BFR.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildPassedItemsCountAction);
+            BFR.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), ChildExecutableItemsCountAction);
+            BFR.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), ChildExecutedItemsCountAction);
+            BFR.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), ChildPassedItemsCountAction);
 
             if (context.BusinessFlow.LiteDbId != null && executedFrom == eExecutedFrom.Automation)
             {
@@ -361,30 +358,30 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
             foreach (LiteDbBusinessFlow businessFlow in liteDbBFList)
             {
                 int count = 0;
-                businessFlow.ChildExecutableItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), out count);
+                businessFlow.ChildExecutableItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), out count);
                 ChildExecutableItemsCountActivity = ChildExecutableItemsCountActivity + count;
 
-                businessFlow.ChildExecutedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), out count);
+                businessFlow.ChildExecutedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), out count);
                 ChildExecutedItemsCountActivity = ChildExecutedItemsCountActivity + count;
 
-                businessFlow.ChildPassedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), out count);
+                businessFlow.ChildPassedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), out count);
                 ChildPassedItemsCountActivity = ChildPassedItemsCountActivity + count;
 
-                businessFlow.ChildExecutableItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), out count);
+                businessFlow.ChildExecutableItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), out count);
                 ChildExecutableItemsCountAction = ChildExecutableItemsCountAction + count;
 
-                businessFlow.ChildExecutedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), out count);
+                businessFlow.ChildExecutedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), out count);
                 ChildExecutedItemsCountAction = ChildExecutedItemsCountAction + count;
 
-                businessFlow.ChildPassedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), out count);
+                businessFlow.ChildPassedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), out count);
                 ChildPassedItemsCountAction = ChildPassedItemsCountAction + count;
             }
-            runner.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildExecutableItemsCountActivity);
-            runner.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildExecutedItemsCountActivity);
-            runner.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildPassedItemsCountActivity);
-            runner.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildExecutableItemsCountAction);
-            runner.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildExecutedItemsCountAction);
-            runner.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildPassedItemsCountAction);
+            runner.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), ChildExecutableItemsCountActivity);
+            runner.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), ChildExecutedItemsCountActivity);
+            runner.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), ChildPassedItemsCountActivity);
+            runner.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), ChildExecutableItemsCountAction);
+            runner.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), ChildExecutedItemsCountAction);
+            runner.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), ChildPassedItemsCountAction);
         }
         public override void SetReportRunSet(RunSetReport runSetReport, string logFolder)
         {
@@ -410,31 +407,31 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
             foreach (LiteDbRunner runner in runSet.RunnersColl)
             {
                 int count = 0;
-                runner.ChildExecutableItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), out count);
+                runner.ChildExecutableItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), out count);
                 ChildExecutableItemsCountActivity = ChildExecutableItemsCountActivity + count;
 
-                runner.ChildExecutedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), out count);
+                runner.ChildExecutedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), out count);
                 ChildExecutedItemsCountActivity = ChildExecutedItemsCountActivity + count;
 
-                runner.ChildPassedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), out count);
+                runner.ChildPassedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), out count);
                 ChildPassedItemsCountActivity = ChildPassedItemsCountActivity + count;
 
-                runner.ChildExecutableItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), out count);
+                runner.ChildExecutableItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), out count);
                 ChildExecutableItemsCountAction = ChildExecutableItemsCountAction + count;
 
-                runner.ChildExecutedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), out count);
+                runner.ChildExecutedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), out count);
                 ChildExecutedItemsCountAction = ChildExecutedItemsCountAction + count;
 
-                runner.ChildPassedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), out count);
+                runner.ChildPassedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), out count);
                 ChildPassedItemsCountAction = ChildPassedItemsCountAction + count;
             }
-            runSet.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildExecutableItemsCountActivity);
-            runSet.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildExecutedItemsCountActivity);
-            runSet.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildPassedItemsCountActivity);
+            runSet.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), ChildExecutableItemsCountActivity);
+            runSet.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), ChildExecutedItemsCountActivity);
+            runSet.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activities.ToString(), ChildPassedItemsCountActivity);
 
-            runSet.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildExecutableItemsCountAction);
-            runSet.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildExecutedItemsCountAction);
-            runSet.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildPassedItemsCountAction);
+            runSet.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), ChildExecutableItemsCountAction);
+            runSet.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), ChildExecutedItemsCountAction);
+            runSet.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Actions.ToString(), ChildPassedItemsCountAction);
         }
         public override void RunSetUpdate(ObjectId runSetLiteDbId, ObjectId runnerLiteDbId, GingerRunner gingerRunner)
         {

--- a/Ginger/GingerCoreNET/Run/RunListenerLib/LiteDBRepository.cs
+++ b/Ginger/GingerCoreNET/Run/RunListenerLib/LiteDBRepository.cs
@@ -158,6 +158,11 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
             }
             activity.Acts.ToList().ForEach(action => this.MapActionToLiteDb((GingerCore.Actions.Act)action, context, executedFrom));
             AR.ActionsColl.AddRange(liteDbActionList);
+            //counts
+            AR.ChildExecutableItemsCount.Add("Action", activity.Acts.Count);
+            AR.ChildExecutedItemsCount.Add("Action", (activity.Acts.Count - activity.Acts.Count(x => x.Status == eRunStatus.Pending || x.Status == eRunStatus.Skipped || x.Status == eRunStatus.Blocked)));
+            AR.ChildPassedItemsCount.Add("Action", activity.Acts.Count(x => x.Status == eRunStatus.Passed));
+
             liteDbActivityList.Add(AR);
             SaveObjToReporsitory(AR, liteDbManager.NameInDb<LiteDbActivity>());
             liteDbActionList.Clear();
@@ -212,6 +217,39 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
             context.Runner.CalculateBusinessFlowFinalStatus(context.BusinessFlow);
             BFR.SetReportData(GetBFReportData(context.BusinessFlow, context.Environment));
             BFR.Seq = ++this.bfSeq;
+
+            int ChildExecutableItemsCountActivity = 0;
+            int ChildExecutedItemsCountActivity = 0;
+            int ChildPassedItemsCountActivity = 0;
+
+            ChildExecutableItemsCountActivity = context.BusinessFlow.Activities.Count;
+            ChildExecutedItemsCountActivity = ChildExecutableItemsCountActivity - context.BusinessFlow.Activities.Where(ac => ac.Status == eRunStatus.Pending || ac.Status == eRunStatus.Skipped || ac.Status == eRunStatus.Blocked).Count();
+            ChildPassedItemsCountActivity = context.BusinessFlow.Activities.Where(ac => ac.Status == eRunStatus.Passed).Count();
+
+            BFR.ChildExecutableItemsCount.Add("Activity", ChildExecutableItemsCountActivity);
+            BFR.ChildExecutedItemsCount.Add("Activity", ChildExecutedItemsCountActivity);
+            BFR.ChildPassedItemsCount.Add("Activity", ChildPassedItemsCountActivity);
+
+            int ChildExecutableItemsCountAction = 0;
+            int ChildExecutedItemsCountAction = 0;
+            int ChildPassedItemsCountAction = 0;
+            foreach (LiteDbActivity activity in liteDbActivityList)
+            {
+                int count = 0;
+                
+                activity.ChildExecutableItemsCount.TryGetValue("Action", out count);
+                ChildExecutableItemsCountAction = ChildExecutableItemsCountAction + count;
+
+                activity.ChildExecutedItemsCount.TryGetValue("Action", out count);
+                ChildExecutedItemsCountAction = ChildExecutedItemsCountAction + count;
+
+                activity.ChildPassedItemsCount.TryGetValue("Action", out count);
+                ChildPassedItemsCountAction = ChildPassedItemsCountAction + count;
+            }
+            BFR.ChildExecutableItemsCount.Add("Action", ChildExecutableItemsCountAction);
+            BFR.ChildExecutedItemsCount.Add("Action", ChildExecutedItemsCountAction);
+            BFR.ChildPassedItemsCount.Add("Action", ChildPassedItemsCountAction);
+
             if (context.BusinessFlow.LiteDbId != null && executedFrom == eExecutedFrom.Automation)
             {
                 BFR._id = context.BusinessFlow.LiteDbId;
@@ -302,6 +340,9 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
             {
                 runner.BusinessFlowsColl.RemoveRange(0, gingerRunner.BusinessFlows.Count);
             }
+
+            SetRunnerChildCounts(runner);
+
             runner.SetReportData(gingerReport);
             SaveObjToReporsitory(runner, liteDbManager.NameInDb<LiteDbRunner>());
             if (ExecutionLoggerManager.RunSetReport == null)
@@ -313,16 +354,91 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
             liteDbBFList.Clear();
             lastRunnertStatus = gingerRunner.RunsetStatus;
         }
+        private void SetRunnerChildCounts(LiteDbRunner runner)
+        {
+            int ChildExecutableItemsCountActivity = 0;
+            int ChildExecutedItemsCountActivity = 0;
+            int ChildPassedItemsCountActivity = 0;
+            int ChildExecutableItemsCountAction = 0;
+            int ChildExecutedItemsCountAction = 0;
+            int ChildPassedItemsCountAction = 0;
+            foreach (LiteDbBusinessFlow businessFlow in liteDbBFList)
+            {
+                int count = 0;
+                businessFlow.ChildExecutableItemsCount.TryGetValue("Activity", out count);
+                ChildExecutableItemsCountActivity = ChildExecutableItemsCountActivity + count;
 
+                businessFlow.ChildExecutedItemsCount.TryGetValue("Activity", out count);
+                ChildExecutedItemsCountActivity = ChildExecutedItemsCountActivity + count;
+
+                businessFlow.ChildPassedItemsCount.TryGetValue("Activity", out count);
+                ChildPassedItemsCountActivity = ChildPassedItemsCountActivity + count;
+
+                businessFlow.ChildExecutableItemsCount.TryGetValue("Action", out count);
+                ChildExecutableItemsCountAction = ChildExecutableItemsCountAction + count;
+
+                businessFlow.ChildExecutedItemsCount.TryGetValue("Action", out count);
+                ChildExecutedItemsCountAction = ChildExecutedItemsCountAction + count;
+
+                businessFlow.ChildPassedItemsCount.TryGetValue("Action", out count);
+                ChildPassedItemsCountAction = ChildPassedItemsCountAction + count;
+            }
+            runner.ChildExecutableItemsCount.Add("Activity", ChildExecutableItemsCountActivity);
+            runner.ChildExecutedItemsCount.Add("Activity", ChildExecutedItemsCountActivity);
+            runner.ChildPassedItemsCount.Add("Activity", ChildPassedItemsCountActivity);
+            runner.ChildExecutableItemsCount.Add("Action", ChildExecutableItemsCountAction);
+            runner.ChildExecutedItemsCount.Add("Action", ChildExecutedItemsCountAction);
+            runner.ChildPassedItemsCount.Add("Action", ChildPassedItemsCountAction);
+        }
         public override void SetReportRunSet(RunSetReport runSetReport, string logFolder)
         {
             LiteDbRunSet runSet = new LiteDbRunSet();
             base.SetReportRunSet(runSetReport, logFolder);
             runSet.RunnersColl.AddRange(ExecutionLoggerManager.RunSetReport.liteDbRunnerList);
+
+            SetRunSetChildCounts(runSet);
+
             runSet.SetReportData(runSetReport);
             SaveObjToReporsitory(runSet, liteDbManager.NameInDb<LiteDbRunSet>());
             ExecutionLoggerManager.RunSetReport.liteDbRunnerList.Clear();
             ClearSeq();
+        }
+        private void SetRunSetChildCounts(LiteDbRunSet runSet)
+        {
+            int ChildExecutableItemsCountActivity = 0;
+            int ChildExecutedItemsCountActivity = 0;
+            int ChildPassedItemsCountActivity = 0;
+            int ChildExecutableItemsCountAction = 0;
+            int ChildExecutedItemsCountAction = 0;
+            int ChildPassedItemsCountAction = 0;
+            foreach (LiteDbRunner runner in runSet.RunnersColl)
+            {
+                int count = 0;
+                runner.ChildExecutableItemsCount.TryGetValue("Activity", out count);
+                ChildExecutableItemsCountActivity = ChildExecutableItemsCountActivity + count;
+
+                runner.ChildExecutedItemsCount.TryGetValue("Activity", out count);
+                ChildExecutedItemsCountActivity = ChildExecutedItemsCountActivity + count;
+
+                runner.ChildPassedItemsCount.TryGetValue("Activity", out count);
+                ChildPassedItemsCountActivity = ChildPassedItemsCountActivity + count;
+
+                runner.ChildExecutableItemsCount.TryGetValue("Action", out count);
+                ChildExecutableItemsCountAction = ChildExecutableItemsCountAction + count;
+
+                runner.ChildExecutedItemsCount.TryGetValue("Action", out count);
+                ChildExecutedItemsCountAction = ChildExecutedItemsCountAction + count;
+
+                runner.ChildPassedItemsCount.TryGetValue("Action", out count);
+                ChildPassedItemsCountAction = ChildPassedItemsCountAction + count;
+            }
+            runSet.ChildExecutableItemsCount.Add("Activity", ChildExecutableItemsCountActivity);
+            runSet.ChildExecutedItemsCount.Add("Activity", ChildExecutedItemsCountActivity);
+            runSet.ChildPassedItemsCount.Add("Activity", ChildPassedItemsCountActivity);
+
+            runSet.ChildExecutableItemsCount.Add("Action", ChildExecutableItemsCountAction);
+            runSet.ChildExecutedItemsCount.Add("Action", ChildExecutedItemsCountAction);
+            runSet.ChildPassedItemsCount.Add("Action", ChildPassedItemsCountAction);
         }
         public override void RunSetUpdate(ObjectId runSetLiteDbId, ObjectId runnerLiteDbId, GingerRunner gingerRunner)
         {
@@ -341,6 +457,9 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
                 runner.Elapsed = gingerRunner.BusinessFlows[0].Elapsed;
             }
             runner.RunStatus = (liteDbBFList.Count > 0) ? liteDbBFList[0].RunStatus : eRunStatus.Automated.ToString();
+
+            SetRunnerChildCounts(runner);
+
             SaveObjToReporsitory(runner, liteDbManager.NameInDb<LiteDbRunner>());
             liteDbBFList.Clear();
             LiteDbRunSet runSet = new LiteDbRunSet();
@@ -348,6 +467,9 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
             base.SetReportRunSet(ExecutionLoggerManager.RunSetReport, "");
             runSet.SetReportData(ExecutionLoggerManager.RunSetReport);
             runSet.RunnersColl.AddRange(new List<LiteDbRunner>() { runner });
+            
+            SetRunSetChildCounts(runSet);
+
             SaveObjToReporsitory(runSet, liteDbManager.NameInDb<LiteDbRunSet>());
         }
 

--- a/Ginger/GingerCoreNET/Run/RunListenerLib/LiteDBRepository.cs
+++ b/Ginger/GingerCoreNET/Run/RunListenerLib/LiteDBRepository.cs
@@ -159,9 +159,12 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
             activity.Acts.ToList().ForEach(action => this.MapActionToLiteDb((GingerCore.Actions.Act)action, context, executedFrom));
             AR.ActionsColl.AddRange(liteDbActionList);
             //counts
-            AR.ChildExecutableItemsCount.Add("Action", activity.Acts.Count);
-            AR.ChildExecutedItemsCount.Add("Action", (activity.Acts.Count - activity.Acts.Count(x => x.Status == eRunStatus.Pending || x.Status == eRunStatus.Skipped || x.Status == eRunStatus.Blocked)));
-            AR.ChildPassedItemsCount.Add("Action", activity.Acts.Count(x => x.Status == eRunStatus.Passed));
+            //AR.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), activity.Acts.Count);
+            //AR.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), (activity.Acts.Count - activity.Acts.Count(x => x.Status == eRunStatus.Pending || x.Status == eRunStatus.Skipped || x.Status == eRunStatus.Blocked)));
+            //AR.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), activity.Acts.Count(x => x.Status == eRunStatus.Passed));
+            AR.ChildExecutableItemsCount = activity.Acts.Count(x => x.Active == true);
+            AR.ChildExecutedItemsCount = AR.ChildExecutableItemsCount - activity.Acts.Count(x => x.Status == eRunStatus.Pending || x.Status == eRunStatus.Skipped || x.Status == eRunStatus.Blocked);
+            AR.ChildPassedItemsCount = activity.Acts.Count(x => x.Status == eRunStatus.Passed);
 
             liteDbActivityList.Add(AR);
             SaveObjToReporsitory(AR, liteDbManager.NameInDb<LiteDbActivity>());
@@ -226,29 +229,22 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
             ChildExecutedItemsCountActivity = ChildExecutableItemsCountActivity - context.BusinessFlow.Activities.Where(ac => ac.Status == eRunStatus.Pending || ac.Status == eRunStatus.Skipped || ac.Status == eRunStatus.Blocked).Count();
             ChildPassedItemsCountActivity = context.BusinessFlow.Activities.Where(ac => ac.Status == eRunStatus.Passed).Count();
 
-            BFR.ChildExecutableItemsCount.Add("Activity", ChildExecutableItemsCountActivity);
-            BFR.ChildExecutedItemsCount.Add("Activity", ChildExecutedItemsCountActivity);
-            BFR.ChildPassedItemsCount.Add("Activity", ChildPassedItemsCountActivity);
+            BFR.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildExecutableItemsCountActivity);
+            BFR.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildExecutedItemsCountActivity);
+            BFR.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildPassedItemsCountActivity);
 
             int ChildExecutableItemsCountAction = 0;
             int ChildExecutedItemsCountAction = 0;
             int ChildPassedItemsCountAction = 0;
             foreach (LiteDbActivity activity in liteDbActivityList)
             {
-                int count = 0;
-                
-                activity.ChildExecutableItemsCount.TryGetValue("Action", out count);
-                ChildExecutableItemsCountAction = ChildExecutableItemsCountAction + count;
-
-                activity.ChildExecutedItemsCount.TryGetValue("Action", out count);
-                ChildExecutedItemsCountAction = ChildExecutedItemsCountAction + count;
-
-                activity.ChildPassedItemsCount.TryGetValue("Action", out count);
-                ChildPassedItemsCountAction = ChildPassedItemsCountAction + count;
+                ChildExecutableItemsCountAction = ChildExecutableItemsCountAction + activity.ChildExecutableItemsCount;
+                ChildExecutedItemsCountAction = ChildExecutedItemsCountAction + activity.ChildExecutedItemsCount;
+                ChildPassedItemsCountAction = ChildPassedItemsCountAction + activity.ChildPassedItemsCount;
             }
-            BFR.ChildExecutableItemsCount.Add("Action", ChildExecutableItemsCountAction);
-            BFR.ChildExecutedItemsCount.Add("Action", ChildExecutedItemsCountAction);
-            BFR.ChildPassedItemsCount.Add("Action", ChildPassedItemsCountAction);
+            BFR.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildExecutableItemsCountAction);
+            BFR.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildExecutedItemsCountAction);
+            BFR.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildPassedItemsCountAction);
 
             if (context.BusinessFlow.LiteDbId != null && executedFrom == eExecutedFrom.Automation)
             {
@@ -365,30 +361,30 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
             foreach (LiteDbBusinessFlow businessFlow in liteDbBFList)
             {
                 int count = 0;
-                businessFlow.ChildExecutableItemsCount.TryGetValue("Activity", out count);
+                businessFlow.ChildExecutableItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), out count);
                 ChildExecutableItemsCountActivity = ChildExecutableItemsCountActivity + count;
 
-                businessFlow.ChildExecutedItemsCount.TryGetValue("Activity", out count);
+                businessFlow.ChildExecutedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), out count);
                 ChildExecutedItemsCountActivity = ChildExecutedItemsCountActivity + count;
 
-                businessFlow.ChildPassedItemsCount.TryGetValue("Activity", out count);
+                businessFlow.ChildPassedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), out count);
                 ChildPassedItemsCountActivity = ChildPassedItemsCountActivity + count;
 
-                businessFlow.ChildExecutableItemsCount.TryGetValue("Action", out count);
+                businessFlow.ChildExecutableItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), out count);
                 ChildExecutableItemsCountAction = ChildExecutableItemsCountAction + count;
 
-                businessFlow.ChildExecutedItemsCount.TryGetValue("Action", out count);
+                businessFlow.ChildExecutedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), out count);
                 ChildExecutedItemsCountAction = ChildExecutedItemsCountAction + count;
 
-                businessFlow.ChildPassedItemsCount.TryGetValue("Action", out count);
+                businessFlow.ChildPassedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), out count);
                 ChildPassedItemsCountAction = ChildPassedItemsCountAction + count;
             }
-            runner.ChildExecutableItemsCount.Add("Activity", ChildExecutableItemsCountActivity);
-            runner.ChildExecutedItemsCount.Add("Activity", ChildExecutedItemsCountActivity);
-            runner.ChildPassedItemsCount.Add("Activity", ChildPassedItemsCountActivity);
-            runner.ChildExecutableItemsCount.Add("Action", ChildExecutableItemsCountAction);
-            runner.ChildExecutedItemsCount.Add("Action", ChildExecutedItemsCountAction);
-            runner.ChildPassedItemsCount.Add("Action", ChildPassedItemsCountAction);
+            runner.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildExecutableItemsCountActivity);
+            runner.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildExecutedItemsCountActivity);
+            runner.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildPassedItemsCountActivity);
+            runner.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildExecutableItemsCountAction);
+            runner.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildExecutedItemsCountAction);
+            runner.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildPassedItemsCountAction);
         }
         public override void SetReportRunSet(RunSetReport runSetReport, string logFolder)
         {
@@ -414,31 +410,31 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
             foreach (LiteDbRunner runner in runSet.RunnersColl)
             {
                 int count = 0;
-                runner.ChildExecutableItemsCount.TryGetValue("Activity", out count);
+                runner.ChildExecutableItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), out count);
                 ChildExecutableItemsCountActivity = ChildExecutableItemsCountActivity + count;
 
-                runner.ChildExecutedItemsCount.TryGetValue("Activity", out count);
+                runner.ChildExecutedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), out count);
                 ChildExecutedItemsCountActivity = ChildExecutedItemsCountActivity + count;
 
-                runner.ChildPassedItemsCount.TryGetValue("Activity", out count);
+                runner.ChildPassedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), out count);
                 ChildPassedItemsCountActivity = ChildPassedItemsCountActivity + count;
 
-                runner.ChildExecutableItemsCount.TryGetValue("Action", out count);
+                runner.ChildExecutableItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), out count);
                 ChildExecutableItemsCountAction = ChildExecutableItemsCountAction + count;
 
-                runner.ChildExecutedItemsCount.TryGetValue("Action", out count);
+                runner.ChildExecutedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), out count);
                 ChildExecutedItemsCountAction = ChildExecutedItemsCountAction + count;
 
-                runner.ChildPassedItemsCount.TryGetValue("Action", out count);
+                runner.ChildPassedItemsCount.TryGetValue(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), out count);
                 ChildPassedItemsCountAction = ChildPassedItemsCountAction + count;
             }
-            runSet.ChildExecutableItemsCount.Add("Activity", ChildExecutableItemsCountActivity);
-            runSet.ChildExecutedItemsCount.Add("Activity", ChildExecutedItemsCountActivity);
-            runSet.ChildPassedItemsCount.Add("Activity", ChildPassedItemsCountActivity);
+            runSet.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildExecutableItemsCountActivity);
+            runSet.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildExecutedItemsCountActivity);
+            runSet.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Activity.ToString(), ChildPassedItemsCountActivity);
 
-            runSet.ChildExecutableItemsCount.Add("Action", ChildExecutableItemsCountAction);
-            runSet.ChildExecutedItemsCount.Add("Action", ChildExecutedItemsCountAction);
-            runSet.ChildPassedItemsCount.Add("Action", ChildPassedItemsCountAction);
+            runSet.ChildExecutableItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildExecutableItemsCountAction);
+            runSet.ChildExecutedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildExecutedItemsCountAction);
+            runSet.ChildPassedItemsCount.Add(HTMLReportConfiguration.eExecutionStatisticsCountBy.Action.ToString(), ChildPassedItemsCountAction);
         }
         public override void RunSetUpdate(ObjectId runSetLiteDbId, ObjectId runnerLiteDbId, GingerRunner gingerRunner)
         {

--- a/Ginger/GingerCoreNET/Run/RunSetActions/RunSetActionHTMLReportSendEmail.cs
+++ b/Ginger/GingerCoreNET/Run/RunSetActions/RunSetActionHTMLReportSendEmail.cs
@@ -776,7 +776,7 @@ namespace Ginger.Run.RunSetActions
                         }
                     }
                     List<string> selectedBFFields = new List<string> { BusinessFlowReport.Fields.Seq, BusinessFlowReport.Fields.Name, BusinessFlowReport.Fields.Description, BusinessFlowReport.Fields.RunDescription,
-                        BusinessFlowReport.Fields.ExecutionDuration, BusinessFlowReport.Fields.RunStatus, BusinessFlowReport.Fields.PassPercent};
+                        BusinessFlowReport.Fields.ExecutionDuration, BusinessFlowReport.Fields.RunStatus, BusinessFlowReport.Fields.ExecutionRate, BusinessFlowReport.Fields.PassPercent };
                     foreach (HTMLReportConfigFieldToSelect selectedField_internal in currentTemplate.BusinessFlowFieldsToSelect.Where(x => (x.IsSelected == true && x.FieldType == Ginger.Reports.FieldsType.Field.ToString() && selectedBFFields.Contains(x.FieldKey))))
                     {
                         string fieldName = EmailToObjectFieldName(selectedField_internal.FieldKey);
@@ -817,6 +817,10 @@ namespace Ginger.Run.RunSetActions
                         else if (selectedField_internal.FieldKey == BusinessFlowReport.Fields.RunStatus)
                         {
                             fieldsValuesHTMLTableCells.Append("<td style='padding:10px;border:1px solid #dddddd;' class='Status" + (br.GetType().GetProperty(fieldName).GetValue(br)).ToString() + "'>" + br.GetType().GetProperty(fieldName).GetValue(br) + "</td>");
+                        }
+                        else if (selectedField_internal.FieldKey == BusinessFlowReport.Fields.ExecutionRate)
+                        {
+                            fieldsValuesHTMLTableCells.Append(tableStyle + br.GetType().GetProperty(fieldName).GetValue(br) + " %</td>");
                         }
                         else if (selectedField_internal.FieldKey == BusinessFlowReport.Fields.PassPercent)
                         {


### PR DESCRIPTION
Child_ItemsCount have been used for calculation of execution/pass rate based on activity or action level configuration on lite db report