### PR TITLE
Bug fix/8308 changes are not been saved when copying pasting tree items resources and b fs

### DIFF
--- a/Ginger/Ginger/SolutionWindows/TreeViewItems/ApplicationModelsTreeItems/AppApiModelTreeItem.cs
+++ b/Ginger/Ginger/SolutionWindows/TreeViewItems/ApplicationModelsTreeItems/AppApiModelTreeItem.cs
@@ -107,6 +107,7 @@ namespace GingerWPF.TreeViewItemsLib.ApplicationModelsTreeItems
             RepositoryItemBase copiedItem = CopyTreeItemWithNewName((RepositoryItemBase)item);
             if (copiedItem != null)
             {
+                copiedItem.DirtyStatus = eDirtyStatus.NoTracked;
                 HandleGlobalModelParameters(item, copiedItem);          // avoid generating new GUIDs for Global Model Parameters associated to API Model being copied
                 (WorkSpace.Instance.SolutionRepository.GetItemRepositoryFolder(((RepositoryItemBase)item))).AddRepositoryItem(copiedItem);
             }

--- a/Ginger/Ginger/SolutionWindows/TreeViewItems/ApplicationModelsTreeItems/AppApiModelsFolderTreeItem.cs
+++ b/Ginger/Ginger/SolutionWindows/TreeViewItems/ApplicationModelsTreeItems/AppApiModelsFolderTreeItem.cs
@@ -201,6 +201,7 @@ namespace GingerWPF.TreeViewItemsLib.ApplicationModelsTreeItems
             RepositoryItemBase copiedItem = CopyTreeItemWithNewName((RepositoryItemBase)nodeItemToCopy);
             if (copiedItem != null)
             {
+                copiedItem.DirtyStatus = eDirtyStatus.NoTracked;
                 AppApiModelTreeItem.HandleGlobalModelParameters(nodeItemToCopy, copiedItem);            // avoid generating new GUIDs for Global Model Parameters associated to API Model being copied
                 ((RepositoryFolderBase)(((ITreeViewItem)targetFolderNode).NodeObject())).AddRepositoryItem(copiedItem);
                 return true;

--- a/Ginger/Ginger/SolutionWindows/TreeViewItems/HTMLGingerReportTreeItem.cs
+++ b/Ginger/Ginger/SolutionWindows/TreeViewItems/HTMLGingerReportTreeItem.cs
@@ -126,6 +126,7 @@ namespace Ginger.SolutionWindows.TreeViewItems
 
             if (copiedItem != null)
             {
+                copiedItem.DirtyStatus = eDirtyStatus.NoTracked;
                 //TODO: why below is needed??
                 copiedItem.ID = copiedItem.SetReportTemplateSequence(true);
                 copiedItem.IsDefault = false;

--- a/Ginger/Ginger/SolutionWindows/TreeViewItems/NewTreeViewItemBase.cs
+++ b/Ginger/Ginger/SolutionWindows/TreeViewItems/NewTreeViewItemBase.cs
@@ -138,7 +138,10 @@ namespace GingerWPF.TreeViewItemsLib
                 //}  
                 RepositoryItemBase copiedItem = CopyTreeItemWithNewName((RepositoryItemBase)item);
                 if (copiedItem != null)
+                {
+                    copiedItem.DirtyStatus = eDirtyStatus.NoTracked;
                     (WorkSpace.Instance.SolutionRepository.GetItemRepositoryFolder(((RepositoryItemBase)item))).AddRepositoryItem(copiedItem);
+                }
             }
             else
             {
@@ -155,6 +158,7 @@ namespace GingerWPF.TreeViewItemsLib
                 RepositoryItemBase copiedItem = CopyTreeItemWithNewName((RepositoryItemBase)nodeItemToCopy);
                 if (copiedItem != null)
                 {
+                    copiedItem.DirtyStatus = eDirtyStatus.NoTracked;
                     ((RepositoryFolderBase)(((ITreeViewItem)targetFolderNode).NodeObject())).AddRepositoryItem(copiedItem);
                     return true;
                 }
@@ -175,6 +179,7 @@ namespace GingerWPF.TreeViewItemsLib
                 RepositoryItemBase copiedItem = CopyTreeItemWithNewName((RepositoryItemBase)childItemToCopy);
                 if (copiedItem != null)
                 {
+                    copiedItem.DirtyStatus = eDirtyStatus.NoTracked;
                     ((RepositoryFolderBase)(((ITreeViewItem)this).NodeObject())).AddRepositoryItem(copiedItem);
                 }
             }

--- a/Ginger/Ginger/SolutionWindows/TreeViewItems/TreeViewItemBase.cs
+++ b/Ginger/Ginger/SolutionWindows/TreeViewItems/TreeViewItemBase.cs
@@ -223,6 +223,8 @@ namespace Ginger.SolutionWindows.TreeViewItems
                 RepositoryItemBase copiedItem = CopyTreeItemWithNewName((RepositoryItemBase)item);
                 if (copiedItem != null)
                 {
+                    copiedItem.DirtyStatus = Amdocs.Ginger.Common.Enums.eDirtyStatus.NoTracked;
+
                     //Save copy to target folder
                     // check me                    
                     WorkSpace.Instance.SolutionRepository.SaveRepositoryItem(copiedItem);
@@ -258,6 +260,7 @@ namespace Ginger.SolutionWindows.TreeViewItems
                 RepositoryItemBase copiedItem = CopyTreeItemWithNewName((RepositoryItemBase)nodeItemToCopy);
                 if (copiedItem != null)
                 {
+                    copiedItem.DirtyStatus = Amdocs.Ginger.Common.Enums.eDirtyStatus.NoTracked;
                     //Save copy to target folder                    
                     WorkSpace.Instance.SolutionRepository.SaveRepositoryItem(copiedItem);
 

--- a/Ginger/GingerCoreCommon/Repository/RepositoryItemBase.cs
+++ b/Ginger/GingerCoreCommon/Repository/RepositoryItemBase.cs
@@ -596,7 +596,6 @@ namespace Amdocs.Ginger.Repository
                 duplicatedItem= duplicatedItem.GetUpdatedRepoItem(guidMappingList);
             }
 
-            duplicatedItem.StartDirtyTracking();
             duplicatedItem.DirtyStatus = eDirtyStatus.Modified;
 
             return duplicatedItem;

--- a/Ginger/GingerCoreCommon/Repository/RepositoryItemBase.cs
+++ b/Ginger/GingerCoreCommon/Repository/RepositoryItemBase.cs
@@ -596,8 +596,8 @@ namespace Amdocs.Ginger.Repository
                 duplicatedItem= duplicatedItem.GetUpdatedRepoItem(guidMappingList);
             }
 
+            duplicatedItem.StartDirtyTracking();
             duplicatedItem.DirtyStatus = eDirtyStatus.Modified;
-
 
             return duplicatedItem;
         }


### PR DESCRIPTION
Changes are lost for pasted/duplicated Tree Items on reloading solution : FIXED

The Dirty tracing for the recently added (pasted/duplicated) **tree item** doesn't gets initialized as we were updating their Dirty status to modified during the copy process.

Fix : setting dirty status to NoTrack in order to start their associated properties tracking and get the changes reflected once saved.