### PR TITLE
Update ActScriptEditPage.xaml.cs

### DIFF
--- a/Ginger/Ginger/Actions/ActionEditPages/ActScriptEditPage.xaml.cs
+++ b/Ginger/Ginger/Actions/ActionEditPages/ActScriptEditPage.xaml.cs
@@ -137,7 +137,7 @@ namespace Ginger.Actions
             {
                 InterpreterPathPanel.Visibility = Visibility.Visible;
                 fileEntries = Directory.EnumerateFiles(SHFilesPath, "*.*", SearchOption.AllDirectories)
-               .Where(s => s.ToLower().EndsWith(".vbs") || s.ToLower().EndsWith(".js") || s.ToLower().EndsWith(".pl") || s.ToLower().EndsWith(".bat") || s.ToLower().EndsWith(".cmd")).ToArray();
+               .Where(s => s.ToLower().EndsWith(".vbs") || s.ToLower().EndsWith(".js") || s.ToLower().EndsWith(".pl") || s.ToLower().EndsWith(".bat") || s.ToLower().EndsWith(".ps1") || s.ToLower().EndsWith(".py") || s.ToLower().EndsWith(".cmd")).ToArray();
             }
             else if (interpreterType == ActScript.eScriptInterpreterType.BAT)
             {


### PR DESCRIPTION
The fix for the issue in Script Action:
when **Other** interpreter is chosen then powershell and python files do **not** appear in drop down list.