### PR TITLE
Bug fix/pom edit page live spy element property added with null value

### DIFF
--- a/Ginger/GingerCore/Drivers/JavaDriverLib/JavaDriver.cs
+++ b/Ginger/GingerCore/Drivers/JavaDriverLib/JavaDriver.cs
@@ -2468,7 +2468,12 @@ namespace GingerCore.Drivers.JavaDriverLib
                     if (valueList.Count != 0)
                         PValue = valueList.ElementAt(0);
                 }
-                list.Add(new ControlProperty() { Name = PName, Value = PValue });
+
+                if (!string.IsNullOrEmpty(PValue))
+                {
+                    list.Add(new ControlProperty() { Name = PName, Value = PValue });
+                }
+
             }
             //TODO:J.G: Fix it for JEDITOR Elements
 


### PR DESCRIPTION
Bug 9063:POM Edit page - Live Spy - Element property added with null value
Bug 9064:Java POM - Auto Pilot adding elements which contains element properties with null values