### PR TITLE
Bug fix/official release 4 1 bugs

### DIFF
--- a/Ginger/GingerCoreNET/Run/ApplicationAgent.cs
+++ b/Ginger/GingerCoreNET/Run/ApplicationAgent.cs
@@ -82,26 +82,19 @@ namespace GingerCore.Platforms
             get { return mAgent; }
             set
             {
-                bool bTriggerPropertyChange = true;
-                if (mAgent != null) mAgent.PropertyChanged -= Agent_OnPropertyChange;
-                mAgent = (Agent)value;
+                if (mAgent != null)
+                    mAgent.PropertyChanged -= Agent_OnPropertyChange;
+
+                mAgent = value;
                 if (mAgent != null)
                 {
-                    if (mAgent.Name == AgentName)
-                    {
-                        bTriggerPropertyChange = false;
-                    }
-
                     AgentName = mAgent.Name;
                     mAgent.PropertyChanged += Agent_OnPropertyChange;
                 }
-                if (bTriggerPropertyChange)
-                {
-                    OnPropertyChanged(nameof(Agent));
-                    OnPropertyChanged(nameof(AgentName));
-                    OnPropertyChanged(nameof(AgentID));
-                    OnPropertyChanged(nameof(AppAndAgent));
-                }
+                OnPropertyChanged(nameof(Agent));
+                OnPropertyChanged(nameof(AgentName));
+                OnPropertyChanged(nameof(AgentID));
+                OnPropertyChanged(nameof(AppAndAgent));
             }
         }
 


### PR DESCRIPTION
[5010 ](https://octane.amdocs.com/ui/?p=9001/1002#/entity-navigation?entityType=work_item&id=5010)- When running iOs Native and iOs Web Agent, Agent button does not change to green and Record-Live Spy-Explorer buttons remain disabled

[5014 ](https://octane.amdocs.com/ui/?p=9001/1002#/entity-navigation?entityType=work_item&id=5014)- Android Web Agent shows that Agent is down whereas it is already up-and-running