### PR TITLE
Bug fix/ticket 9641 Ginger is not displaying certain Excel cell content because of column header's name

### DIFF
--- a/Ginger/GingerCoreNET/GeneralLib/General.cs
+++ b/Ginger/GingerCoreNET/GeneralLib/General.cs
@@ -444,6 +444,18 @@ namespace GingerCoreNET.GeneralLib
 
             return null;
         }
+        public static string RemoveSpecialCharactersInColumnHeader(string columnHeader)
+        {
+            string specialCharactersToRemove = "./[]()";
+            foreach (char sc in specialCharactersToRemove)
+            {
+                if (columnHeader.Contains(sc.ToString()))
+                {
+                    columnHeader = columnHeader.Replace(sc.ToString(), string.Empty);
+                }
+            }
+            return columnHeader;
+        }
     }
 
 }

--- a/Ginger/GingerCoreNET/Run/Excels/ExcelNPOIOperations.cs
+++ b/Ginger/GingerCoreNET/Run/Excels/ExcelNPOIOperations.cs
@@ -55,7 +55,12 @@ namespace Amdocs.Ginger.CoreNET.ActionsLib
                     }
                     if (!dtExcelTable.Columns.Contains(headerRow.GetCell(c).ToString()))
                     {
-                        dtExcelTable.Columns.Add(headerRow.GetCell(c).ToString().Trim());
+                        if (ColumnHeaderHasSpeicalCharacters(headerRow.GetCell(c).ToString()))
+                        {
+                            dtExcelTable.Columns.Add(headerRow.GetCell(c).ToString().Replace(".", "").Replace("/", ""));
+                        }
+                        else
+                            dtExcelTable.Columns.Add(headerRow.GetCell(c).ToString().Trim());
                     }
                 }
                 var i = 1;
@@ -358,6 +363,15 @@ namespace Amdocs.Ginger.CoreNET.ActionsLib
             mSheet = null;
             mWorkbook.Close();
             mWorkbook = null;
+        }
+
+        private bool ColumnHeaderHasSpeicalCharacters(string columnHeader)
+        {
+            if (columnHeader.Contains(".") || columnHeader.Contains("/"))
+            {
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/Ginger/GingerCoreNET/Run/Excels/ExcelNPOIOperations.cs
+++ b/Ginger/GingerCoreNET/Run/Excels/ExcelNPOIOperations.cs
@@ -55,7 +55,7 @@ namespace Amdocs.Ginger.CoreNET.ActionsLib
                     }
                     if (!dtExcelTable.Columns.Contains(headerRow.GetCell(c).ToString()))
                     {
-                        dtExcelTable.Columns.Add(RemoveSpecialCharactersInColumnHeader(headerRow.GetCell(c).ToString()));
+                        dtExcelTable.Columns.Add(GingerCoreNET.GeneralLib.General.RemoveSpecialCharactersInColumnHeader(headerRow.GetCell(c).ToString()).Trim());
                     }
                 }
                 var i = 1;
@@ -358,18 +358,6 @@ namespace Amdocs.Ginger.CoreNET.ActionsLib
             mSheet = null;
             mWorkbook.Close();
             mWorkbook = null;
-        }
-        private string RemoveSpecialCharactersInColumnHeader(string columnHeader)
-        {
-            string specialCharactersToRemove = "./[]()";
-            foreach (char sc in specialCharactersToRemove)
-            {
-                if (columnHeader.Contains(sc.ToString()))
-                {
-                    columnHeader = columnHeader.Replace(sc.ToString(), string.Empty);
-                }
-            }
-            return columnHeader.Trim();
         }
     }
 }

--- a/Ginger/GingerCoreNET/Run/Excels/ExcelNPOIOperations.cs
+++ b/Ginger/GingerCoreNET/Run/Excels/ExcelNPOIOperations.cs
@@ -55,12 +55,7 @@ namespace Amdocs.Ginger.CoreNET.ActionsLib
                     }
                     if (!dtExcelTable.Columns.Contains(headerRow.GetCell(c).ToString()))
                     {
-                        if (ColumnHeaderHasSpeicalCharacters(headerRow.GetCell(c).ToString()))
-                        {
-                            dtExcelTable.Columns.Add(headerRow.GetCell(c).ToString().Replace(".", "").Replace("/", ""));
-                        }
-                        else
-                            dtExcelTable.Columns.Add(headerRow.GetCell(c).ToString().Trim());
+                        dtExcelTable.Columns.Add(RemoveSpecialCharactersInColumnHeader(headerRow.GetCell(c).ToString()));
                     }
                 }
                 var i = 1;
@@ -364,14 +359,17 @@ namespace Amdocs.Ginger.CoreNET.ActionsLib
             mWorkbook.Close();
             mWorkbook = null;
         }
-
-        private bool ColumnHeaderHasSpeicalCharacters(string columnHeader)
+        private string RemoveSpecialCharactersInColumnHeader(string columnHeader)
         {
-            if (columnHeader.Contains(".") || columnHeader.Contains("/"))
+            string specialCharactersToRemove = "./[]()";
+            foreach (char sc in specialCharactersToRemove)
             {
-                return true;
+                if (columnHeader.Contains(sc.ToString()))
+                {
+                    columnHeader = columnHeader.Replace(sc.ToString(), string.Empty);
+                }
             }
-            return false;
+            return columnHeader.Trim();
         }
     }
 }

--- a/Ginger/GingerCoreNETUnitTest/GeneralTestsLib/GeneralTest.cs
+++ b/Ginger/GingerCoreNETUnitTest/GeneralTestsLib/GeneralTest.cs
@@ -40,6 +40,17 @@ namespace GingerCoreNETUnitTests.GeneralTestsLib
         {
 
         }
+        [TestMethod]
+        public void RemoveSpecialCharactersInColumnHeader()
+        {
+            //Arrange
+            string stringWithSpecialCharactersToRemove = "First. Name";
+            //Act
+            string stringAfterRemoval = GingerCoreNET.GeneralLib.General.RemoveSpecialCharactersInColumnHeader(stringWithSpecialCharactersToRemove);
+
+            //Assert
+            Assert.AreEqual("First Name", stringAfterRemoval);
+        }
 
 
         // Put back after moving to .NET core 3
@@ -96,10 +107,10 @@ namespace GingerCoreNETUnitTests.GeneralTestsLib
         //        AssemblyName name = (from x in referencedAssemblies where x.Name == s select x).FirstOrDefault();                
         //        Assert.IsTrue(name != null, "Verify assembly ref exist - " + s);
         //    }
-            
-            
-            
+
+
+
         //}
-        
+
     }
 }


### PR DESCRIPTION
Excel Action - cell content are not displayed on Ginger

fixed the issue by checking whether the column name contains a special character which causes problem, if the special character is present on the column header, we remove it.
the special characters that caused problem were { "." , "/", "(" , ")" , "[", "]" }