### PR TITLE
Fixed an issue with the Undo Functionality in Runset tab

### DIFF
--- a/Ginger/Ginger/RunSetPageLib/NewRunSetPage.xaml.cs
+++ b/Ginger/Ginger/RunSetPageLib/NewRunSetPage.xaml.cs
@@ -69,6 +69,7 @@ namespace Ginger.Run
         int mFlowX = 0;
         int mFlowY = 0;
         bool IsSelectedItemSyncWithExecution = true;//execution and selected items are synced as default   
+        private bool IsCalledFromxUndoBtn = false;
         SingleItemTreeViewSelectionPage mRunSetsSelectionPage = null;
         SingleItemTreeViewSelectionPage mBusFlowsSelectionPage = null;
         RunsetOperationsPage mRunsetOperations = null;
@@ -1264,7 +1265,7 @@ namespace Ginger.Run
             try
             {
                 bool bIsRunsetDirty = mRunSetConfig != null && mRunSetConfig.DirtyStatus == eDirtyStatus.Modified;
-                if (bIsRunsetDirty)
+                if (bIsRunsetDirty && !IsCalledFromxUndoBtn)
                 {
                     UserSelectionSaveOrUndoRunsetChanges();
                 }
@@ -2680,6 +2681,7 @@ namespace Ginger.Run
             {
                 if (CheckIfExecutionIsInProgress()) { return; }
 
+                IsCalledFromxUndoBtn = true;
                 mRunSetConfig.GingerRunners.CollectionChanged -= Runners_CollectionChanged;
 
                 if (Ginger.General.UndoChangesInRepositoryItem(mRunSetConfig, true))
@@ -2699,6 +2701,7 @@ namespace Ginger.Run
                 {
                     mRunSetConfig.GingerRunners.CollectionChanged -= Runners_CollectionChanged;
                     mRunSetConfig.GingerRunners.CollectionChanged += Runners_CollectionChanged;
+                    IsCalledFromxUndoBtn = false;
                 }
             }
         }


### PR DESCRIPTION
When making changes like adding or removing BFs from Runners, Undo operation was not reverting the BFs to the previous saved state