### PR TITLE
Duplicating or copying a Runset throws null exception handeling

### DIFF
--- a/Ginger/Ginger/SolutionWindows/TreeViewItems/NewTreeViewItemBase.cs
+++ b/Ginger/Ginger/SolutionWindows/TreeViewItems/NewTreeViewItemBase.cs
@@ -144,7 +144,7 @@ namespace GingerWPF.TreeViewItemsLib
                 }
                 catch (Exception ex)
                 {
-                    Reporter.ToLog(eLogLevel.DEBUG, "Duplicating tree item", ex);
+                    Reporter.ToLog(eLogLevel.ERROR, "Duplicating tree item", ex);
                 }
                 finally
                 {

--- a/Ginger/GingerCoreCommon/Run/RunSetConfig.cs
+++ b/Ginger/GingerCoreCommon/Run/RunSetConfig.cs
@@ -379,7 +379,7 @@ x.Status == Amdocs.Ginger.CoreNET.Execution.eRunStatus.Skipped)
         {
             foreach (GingerRunner GR in GingerRunners)
             {
-                if (GR.Executor.IsUpdateBusinessFlowRunList)
+                if (GR.Executor != null && GR.Executor.IsUpdateBusinessFlowRunList)
                 {
                     GR.Executor.UpdateBusinessFlowsRunList();
                 }


### PR DESCRIPTION
handled null exception being thrown due to serialization changes when… duplicating or copying a Runset