### PR TITLE
Fixed Ginger crash while sending data to centralized db

### DIFF
--- a/Ginger/GingerCoreNET/Run/GingerExecutionEngine.cs
+++ b/Ginger/GingerCoreNET/Run/GingerExecutionEngine.cs
@@ -4162,13 +4162,22 @@ namespace Ginger.Run
                 if (mStopRun)
                     break;
 
-                if (act.Active && act.Status != Amdocs.Ginger.CoreNET.Execution.eRunStatus.Failed) act.Status = Amdocs.Ginger.CoreNET.Execution.eRunStatus.Blocked;
+                if (act.Active && act.Status != Amdocs.Ginger.CoreNET.Execution.eRunStatus.Failed)
+                {
+                    act.Status = Amdocs.Ginger.CoreNET.Execution.eRunStatus.Blocked;
+                }
                 if (WorkSpace.Instance != null && WorkSpace.Instance.Solution != null && WorkSpace.Instance.Solution.LoggerConfigurations.SelectedDataRepositoryMethod == DataRepositoryMethod.LiteDB)
                 {
-                    NotifyActionEnd(act);
+                    //To avoid repeat call to NotifyActionEnd for the same action
+                    if (act.Status == Amdocs.Ginger.CoreNET.Execution.eRunStatus.Blocked)
+                    {
+                        NotifyActionEnd(act);
+                    }
                 }
-                if (CurrentBusinessFlow.CurrentActivity.Acts.IsLastItem()) break;
-
+                if (CurrentBusinessFlow.CurrentActivity.Acts.IsLastItem())
+                {
+                    break;
+                }
                 else
                 {
                     CurrentBusinessFlow.CurrentActivity.Acts.MoveNext();

--- a/Ginger/GingerCoreNET/Run/RunListenerLib/LiteDBRepository.cs
+++ b/Ginger/GingerCoreNET/Run/RunListenerLib/LiteDBRepository.cs
@@ -95,7 +95,7 @@ namespace Amdocs.Ginger.CoreNET.Run.RunListenerLib
                     {
                         if (File.Exists(completeSSPath))
                         {
-                            File.Delete(completeSSPath);
+                            continue;
                         }
                         File.Move(action.ScreenShots[s], completeSSPath);
                         action.ScreenShots[s] = completeSSPath;


### PR DESCRIPTION
Fixed screenshot move issue + ginger crash while sending data to centralized db using during execution option