### PR TITLE
Load Solution warning on newer Ginger versions than the Solution files versions

### DIFF
--- a/Ginger/GingerCoreCommon/ReporterLib/UserMsgsPool.cs
+++ b/Ginger/GingerCoreCommon/ReporterLib/UserMsgsPool.cs
@@ -154,7 +154,8 @@ namespace Amdocs.Ginger.Common
         FailedToPublishRepositoryInfo,
         MissingErrorString,
         RunsetAutoRunResult,
-        RunsetAutoConfigBackWarn
+        RunsetAutoConfigBackWarn,
+        SolutionOpenedOnNewerVersion
     }
 
     public static class UserMsgsPool
@@ -167,7 +168,7 @@ namespace Amdocs.Ginger.Common
             //Add user messages to the pool
             #region General Application Messages
             Reporter.UserMsgsPool.Add(eUserMsgKey.GherkinNotifyFeatureFileExists, new UserMsg(eUserMsgType.ERROR, "Feature File Already Exists", "Feature File with the same name already exist - '{0}'." + Environment.NewLine + "Please select another Feature File to continue.", eUserMsgOption.OK, eUserMsgSelection.None));
-            Reporter.UserMsgsPool.Add(eUserMsgKey.GherkinNotifyFeatureFileSelectedFromTheSolution, new UserMsg(eUserMsgType.ERROR, "Feature File Already Exists", "Feature File - '{0}'." + Environment.NewLine + "Selected From The Solution folder hence its already exist and cannot be copy to the same place" + Environment.NewLine + "Please select another Feature File to continue.", eUserMsgOption.OK, eUserMsgSelection.None));
+            Reporter.UserMsgsPool.Add(eUserMsgKey.GherkinNotifyFeatureFileSelectedFromTheSolution, new UserMsg(eUserMsgType.ERROR, "Feature File Already Exists", "Feature File - '{0}'." + Environment.NewLine + "Selected From The Solution folder hence its already exist and cannot be copied to the same place" + Environment.NewLine + "Please select another Feature File to continue.", eUserMsgOption.OK, eUserMsgSelection.None));
             Reporter.UserMsgsPool.Add(eUserMsgKey.GherkinNotifyBFIsNotExistForThisFeatureFile, new UserMsg(eUserMsgType.ERROR, GingerDicser.GetTermResValue(eTermResKey.BusinessFlow) + " Is Not Exists", GingerDicser.GetTermResValue(eTermResKey.BusinessFlow) + " has to been generated for Feature File - '{0}'." + Environment.NewLine + Environment.NewLine + "Please create " + GingerDicser.GetTermResValue(eTermResKey.BusinessFlow) + " from the Editor Page.", eUserMsgOption.OK, eUserMsgSelection.None));
             Reporter.UserMsgsPool.Add(eUserMsgKey.GherkinFileNotFound, new UserMsg(eUserMsgType.ERROR, "Gherkin File Not Found", "Gherkin file was not found at the path: '{0}'.", eUserMsgOption.OK, eUserMsgSelection.None));
             Reporter.UserMsgsPool.Add(eUserMsgKey.GherkinColumnNotExist, new UserMsg(eUserMsgType.WARN, "Column Not Exist", "Cant find value for: '{0}' Item/s. since column/s not exist in example table", eUserMsgOption.OK, eUserMsgSelection.None));
@@ -198,8 +199,8 @@ namespace Amdocs.Ginger.Common
             Reporter.UserMsgsPool.Add(eUserMsgKey.StaticWarnMessage, new UserMsg(eUserMsgType.WARN, "Warning", "{0}", eUserMsgOption.OK, eUserMsgSelection.None));
             Reporter.UserMsgsPool.Add(eUserMsgKey.StaticInfoMessage, new UserMsg(eUserMsgType.INFO, "Info", "{0}", eUserMsgOption.OK, eUserMsgSelection.None));
             Reporter.UserMsgsPool.Add(eUserMsgKey.StaticQuestionsMessage, new UserMsg(eUserMsgType.QUESTION, "Question", "{0}", eUserMsgOption.YesNo, eUserMsgSelection.No));
-            Reporter.UserMsgsPool.Add(eUserMsgKey.AskIfSureWantToClose, new UserMsg(eUserMsgType.QUESTION, "Close Ginger", "Are you sure you want to close Ginger?" + Environment.NewLine + Environment.NewLine + "Notice: Un-saved changes won't be saved.", eUserMsgOption.YesNo, eUserMsgSelection.No));
-            Reporter.UserMsgsPool.Add(eUserMsgKey.AskIfSureWantToRestart, new UserMsg(eUserMsgType.QUESTION, "Restart Ginger", "Are you sure you want to Restart Ginger?" + Environment.NewLine + Environment.NewLine + "Notice: Un-saved changes won't be saved.", eUserMsgOption.YesNo, eUserMsgSelection.No));
+            Reporter.UserMsgsPool.Add(eUserMsgKey.AskIfSureWantToClose, new UserMsg(eUserMsgType.QUESTION, "Close Ginger", "Are you sure you want to close Ginger?" + Environment.NewLine + Environment.NewLine + "Notice: Unsaved changes won't be saved.", eUserMsgOption.YesNo, eUserMsgSelection.No));
+            Reporter.UserMsgsPool.Add(eUserMsgKey.AskIfSureWantToRestart, new UserMsg(eUserMsgType.QUESTION, "Restart Ginger", "Are you sure you want to Restart Ginger?" + Environment.NewLine + Environment.NewLine + "Notice: Unsaved changes won't be saved.", eUserMsgOption.YesNo, eUserMsgSelection.No));
 
             Reporter.UserMsgsPool.Add(eUserMsgKey.BusinessFlowNeedTargetApplication, new UserMsg(eUserMsgType.WARN, "Target Application Not Selected", "Target Application Not Selected! Please Select at least one Target Application", eUserMsgOption.OK, eUserMsgSelection.None));
 
@@ -406,6 +407,7 @@ namespace Amdocs.Ginger.Common
             Reporter.UserMsgsPool.Add(eUserMsgKey.RefreshTreeGroupFailed, new UserMsg(eUserMsgType.ERROR, "Refresh", "Failed to perform the refresh operation." + Environment.NewLine + "Error Details: '{0}'.", eUserMsgOption.OK, eUserMsgSelection.None));
             Reporter.UserMsgsPool.Add(eUserMsgKey.FailedToDeleteRepoItem, new UserMsg(eUserMsgType.ERROR, "Delete", "Failed to perform the delete operation." + Environment.NewLine + "Error Details: '{0}'.", eUserMsgOption.OK, eUserMsgSelection.None));
             Reporter.UserMsgsPool.Add(eUserMsgKey.InvalidEncryptionKey, new UserMsg(eUserMsgType.WARN, "Encryption Key", "Encryption key must be 8-16 in lenght and should contain atleast 1 cap, 1 small, 1 digit and 1 special char.", eUserMsgOption.OK, eUserMsgSelection.None));
+            Reporter.UserMsgsPool.Add(eUserMsgKey.SolutionOpenedOnNewerVersion, new UserMsg(eUserMsgType.QUESTION, "Load Solution", "Note: Ginger version is higher than the loaded Solution version which will make it incompatible with older versions of Ginger, are you sure you want to continue with loading the Solution?", eUserMsgOption.YesNo, eUserMsgSelection.No));
 
             Reporter.UserMsgsPool.Add(eUserMsgKey.FolderExistsWithName, new UserMsg(eUserMsgType.WARN, "Folder Creation Failed", "Folder with same name already exists. Please choose a different name for the folder.", eUserMsgOption.OK, eUserMsgSelection.None));
             Reporter.UserMsgsPool.Add(eUserMsgKey.UpdateApplicationNameChangeInSolution, new UserMsg(eUserMsgType.WARN, "Target Application Name Change", "Do you want to automatically update the Target Application name in all Solution items?" + Environment.NewLine + Environment.NewLine + "Note: If you choose 'Yes', changes won't be saved, for saving them please click 'SaveAll'", eUserMsgOption.YesNo, eUserMsgSelection.Yes));

--- a/Ginger/GingerCoreNET/SolutionRepositoryLib/UpgradeLib/SolutionUpgrade.cs
+++ b/Ginger/GingerCoreNET/SolutionRepositoryLib/UpgradeLib/SolutionUpgrade.cs
@@ -196,7 +196,6 @@ namespace GingerCoreNET.SolutionRepositoryLib.UpgradeLib
 
             return solutionFilesWithVersion;
         }
-
         internal static bool IsGingerUpgradeNeeded(string solutionFolder, IEnumerable<string> solutionFiles)
         {                        
             ConcurrentBag<Tuple<eGingerVersionComparisonResult, string>> solutionFilesWithVersion = null;
@@ -227,6 +226,33 @@ namespace GingerCoreNET.SolutionRepositoryLib.UpgradeLib
                 Reporter.ToLog(eLogLevel.ERROR, "Error occurred while checking if Solution requires Ginger Upgrade", ex);
                 return false;
             }            
+        }
+        internal static bool IsUserProceedWithLoadSolutionInNewerGingerVersion(string solutionFolder, IEnumerable<string> solutionFiles)
+        {
+            ConcurrentBag<Tuple<eGingerVersionComparisonResult, string>> solutionFilesWithVersion = null;
+            try
+            {
+                if (solutionFilesWithVersion == null)
+                {
+                    solutionFilesWithVersion = SolutionUpgrade.GetSolutionFilesWithVersion(solutionFiles);
+                }
+                ConcurrentBag<string> lowerVersionFiles = SolutionUpgrade.GetSolutionFilesCreatedWithRequiredGingerVersion(solutionFilesWithVersion, eGingerVersionComparisonResult.LowerVersion);
+                if (lowerVersionFiles.Count > 0)
+                {
+                    if(Reporter.ToUser(eUserMsgKey.SolutionOpenedOnNewerVersion) == Amdocs.Ginger.Common.eUserMsgSelection.Yes)
+                    {
+                        return true;
+                    }
+                    Reporter.ToLog(eLogLevel.WARN, "User declined to load the Solution on newer Ginger version, aborting Solution load.");
+                    return false;
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Reporter.ToLog(eLogLevel.ERROR, "Error occurred while checking if the user wants to proceed with loading the Solution on Higher Ginger version", ex);
+                return false;
+            }
         }
 
 
@@ -410,7 +436,6 @@ namespace GingerCoreNET.SolutionRepositoryLib.UpgradeLib
                 return null;//failed to get the version
             }
         }
-
         /// <summary>
         /// Pull and return the Ginger Version (in Long format) which the Solution file was created with 
         /// </summary>

--- a/Ginger/GingerCoreNET/WorkSpaceLib/WorkSpace.cs
+++ b/Ginger/GingerCoreNET/WorkSpaceLib/WorkSpace.cs
@@ -420,6 +420,12 @@ namespace amdocs.ginger.GingerCoreNET
                     return false;
                 }
 
+                if (!SolutionUpgrade.IsUserProceedWithLoadSolutionInNewerGingerVersion(solutionFolder, solutionFiles))
+                {
+                    Reporter.ToLog(eLogLevel.WARN, "Loading Solution- Error: User doesn't wish to proceed with loading the Solution in Newer Ginger version");
+                    return false;
+                }
+
                 Reporter.ToLog(eLogLevel.INFO, "Loading Solution- Loading Solution file xml into object");
                 Solution solution = SolutionOperations.LoadSolution(solutionFile, true, encryptionKey);
                 SolutionOperations solutionOperations = new SolutionOperations(solution);


### PR DESCRIPTION
Added a warning message for the user before opening a Solution on newer Ginger versions than the Solution Files version indicating that continuing with the loading operation will make the Solution incompatible with older versions of Ginger.

I also changed some messages from the UserMsgsPool to be more grammarly accurate.