### PR TITLE
made some fixes to DB action

### DIFF
--- a/Ginger/Ginger/Actions/ActionEditPages/ValidationDBPage.xaml.cs
+++ b/Ginger/Ginger/Actions/ActionEditPages/ValidationDBPage.xaml.cs
@@ -79,6 +79,8 @@ namespace Ginger.Actions
             QueryFile.ValueTextBox.TextChanged += ValueTextBox_TextChanged;
 
             //OLD binding and UI 
+            List<dynamic> operationToExclude = new List<dynamic>();
+            operationToExclude.Add(ActDBValidation.eDBValidationType.Insert);
             GingerCore.General.FillComboFromEnumObj(ValidationCfgComboBox, act.DBValidationType);
 
             //TODO: fix hard coded
@@ -115,6 +117,9 @@ namespace Ginger.Actions
             ComboAutoSelectIfOneItemOnly(ColumnComboBox);
             SetVisibleControlsForAction();
             SetQueryParamsGrid();
+            NewAutomatePage.RaiseEnvComboBoxChanged -= NewAutomatePage_RaiseEnvComboBoxChanged;
+            NewAutomatePage.RaiseEnvComboBoxChanged += NewAutomatePage_RaiseEnvComboBoxChanged;
+
         }
 
         private async void ValueTextBox_TextChanged(object sender, TextChangedEventArgs e)
@@ -244,7 +249,7 @@ namespace Ginger.Actions
 
         private void AddDBOperationTypeInsert(object sender, SelectionChangedEventArgs e)
         {
-            if (((ComboBox)sender) != null && ((ComboBox)sender).SelectedItem != null)
+                if (((ComboBox)sender) != null && ((ComboBox)sender).SelectedItem != null)
             {
                 string dbName = ((ComboBox)sender).SelectedItem.ToString();
                 db = (Database)EA.Dbs.First(m => m.Name == dbName);
@@ -269,6 +274,40 @@ namespace Ginger.Actions
                     }
                 }
             }
+        }
+
+        private void NewAutomatePage_RaiseEnvComboBoxChanged(object sender, EventArgs e)
+        {
+            string selectedAppName = mAct.AppName;
+            string selectedDBName = mAct.DBName;
+
+            object selectAppNameObject = AppNameComboBox.SelectedItem;
+            object selectDBNameObject = DBNameComboBox.SelectedItem;
+
+            AppNameComboBox.Items.Clear();
+            DBNameComboBox.Items.Clear();
+
+            if (Context.GetAsContext(mAct.Context) != null && Context.GetAsContext(mAct.Context).Environment != null)
+            {
+                pe = (from env in WorkSpace.Instance.SolutionRepository.GetAllRepositoryItems<ProjEnvironment>() where env.Name == Context.GetAsContext(mAct.Context).Environment.Name select env).FirstOrDefault();
+
+                if (pe == null)
+                {
+                    return;
+                }
+                foreach (EnvApplication ea in pe.Applications)
+                {
+                    AppNameComboBox.Items.Add(ea.Name);
+                }
+            }
+
+            AppNameComboBox.SelectedItem = selectAppNameObject;
+            mAct.AppName = selectedAppName;
+            AppNameComboBox.Text = selectedAppName;
+
+            DBNameComboBox.SelectedItem = selectDBNameObject;
+            mAct.DBName = selectedDBName;
+            DBNameComboBox.Text = selectedDBName;
         }
 
         private void DBNameComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
1. Insert Operation Type won't be added unless its a cosmosDB database
2. when switching environment, the combo box of environment applications and environment databases are updated with correct values while retaining the old value that was previously set

Thank you for your contribution.
Before submitting this PR, please make sure:
- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is point to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for Existing Functionality
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
