### PR TITLE
Fixed an issue where  In case of all Business Flows of Run set marked…

### DIFF
--- a/Ginger/Ginger/RunSetPageLib/NewRunSetPage.xaml.cs
+++ b/Ginger/Ginger/RunSetPageLib/NewRunSetPage.xaml.cs
@@ -1727,6 +1727,7 @@ namespace Ginger.Run
             finally
             {
                 UpdateRunButtonIcon();
+                UpdateRunnersChartPie();
             }
         }
 
@@ -1771,6 +1772,7 @@ namespace Ginger.Run
             finally
             {
                 UpdateRunButtonIcon();
+                UpdateRunnersChartPie();
             }
         }
 
@@ -2876,6 +2878,10 @@ namespace Ginger.Run
 
             GingerSelfHealingConfiguration selfHealingConfiguration = new GingerSelfHealingConfiguration(mRunSetConfig);
             selfHealingConfiguration.ShowAsWindow();
+        }
+        private void UpdateRunnersChartPie()
+        {
+            mCurrentSelectedRunner.UpdateExecutionStats();
         }
     }
 }

--- a/Ginger/Ginger/RunSetPageLib/RunnerPage.xaml.cs
+++ b/Ginger/Ginger/RunSetPageLib/RunnerPage.xaml.cs
@@ -667,6 +667,7 @@ namespace Ginger.Run
             WorkSpace.Instance.RunsetExecutor.ConfigureRunnerForExecution(mExecutorEngine);
             await mExecutorEngine.RunRunnerAsync();
             GingerCore.General.DoEvents();   //needed?  
+            UpdateExecutionStats();
         }
         public void UpdateRunnerInfo()
         {

--- a/Ginger/GingerCoreNET/Run/GingerExecutionEngine.cs
+++ b/Ginger/GingerCoreNET/Run/GingerExecutionEngine.cs
@@ -4110,6 +4110,7 @@ namespace Ginger.Run
                     {
                         a.Status = Amdocs.Ginger.CoreNET.Execution.eRunStatus.Skipped;
                     }
+                    NotifyActivitySkipped(a);
                 }
 
                 foreach (ActivitiesGroup group in  businessFlow.ActivitiesGroups)
@@ -4118,6 +4119,7 @@ namespace Ginger.Run
                     {
                         group.RunStatus = eActivitiesGroupRunStatus.Skipped;
                     }
+                    NotifyActivityGroupSkipped(group);
                 }
             }
             catch (Exception ex)
@@ -4193,7 +4195,7 @@ namespace Ginger.Run
                 CurrentBusinessFlow = bf;
                 CurrentBusinessFlow.CurrentActivity = bf.Activities.FirstOrDefault();
                 CurrentBusinessFlow.Activities.CurrentItem = CurrentBusinessFlow.CurrentActivity;
-
+                NotifyBusinessFlowSkipped(bf);
                 SetBusinessFlowActivitiesAndActionsSkipStatus(bf);
 
             }


### PR DESCRIPTION
… as Inactive, data wasn't reported to Sealights

2) fixed an issue where  In case of all Business Flows of Run set marked as Inactive, then Run set status is getting displayed as 'Pending'

Thank you for your contribution.
Before submitting this PR, please make sure:
- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is point to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for Existing Functionality
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
