### PR TITLE
loaderElement initialized in ProjectsPage to avoid it throwing null exception

### DIFF
--- a/Ginger/Ginger/SourceControl/SourceControlProjectsPage.xaml.cs
+++ b/Ginger/Ginger/SourceControl/SourceControlProjectsPage.xaml.cs
@@ -44,7 +44,7 @@ namespace Ginger.SourceControl
 
         SolutionInfo solutionInfo = null;
 
-        ImageMakerControl loaderElement;
+        ImageMakerControl loaderElement = new ImageMakerControl();;
 
         GenericWindow genWin = null;
         Button downloadProjBtn = null;
@@ -290,7 +290,6 @@ namespace Ginger.SourceControl
             downloadProjBtn.Content = "Download Selected Solution";
             downloadProjBtn.Click += new RoutedEventHandler(GetProject_Click);
 
-            loaderElement = new ImageMakerControl();
             loaderElement.Name = "xProcessingImage";
             loaderElement.Height = 30;
             loaderElement.Width = 30;

--- a/Ginger/Ginger/SourceControl/SourceControlProjectsPage.xaml.cs
+++ b/Ginger/Ginger/SourceControl/SourceControlProjectsPage.xaml.cs
@@ -44,7 +44,7 @@ namespace Ginger.SourceControl
 
         SolutionInfo solutionInfo = null;
 
-        ImageMakerControl loaderElement = new ImageMakerControl();;
+        ImageMakerControl loaderElement = new ImageMakerControl();
 
         GenericWindow genWin = null;
         Button downloadProjBtn = null;


### PR DESCRIPTION
initialized loaderElement in its declaration instead of inside the ShowAsWindow method as the import global solution window is not being called from ShowAsWindow and that caused a null exception for fetch branch & connnect and search repositories

Thank you for your contribution.
Before submitting this PR, please make sure:
- [x] PR description and commit message should describe the changes done in this PR
- [x] Verify the PR is point to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [x] Latest Code from master or specific release branch is merged to your branch
- [x] No unwanted\commented\junk code is included
- [x] No new warning upon build solution
- [x] Existing unit test cases are passed
- [x] New Unit tests are added for your development
- [x] Sanity Tests are successfully executed for Existing Functionality
- [x] After creating pull request there should not be any conflicts
- [ ] Resolve codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
