### PR TITLE
executing flow or runset would cause that entity to be marked as modified

### DIFF
--- a/Ginger/GingerCoreCommon/Actions/Act.cs
+++ b/Ginger/GingerCoreCommon/Actions/Act.cs
@@ -1687,6 +1687,7 @@ namespace GingerCore.Actions
         {
             if (this != null)
             {
+                PauseDirtyTracking();
                 if (reSetActionErrorHandlerExecutionStatus)
                 {
                     this.ErrorHandlerExecuted = false;
@@ -1761,8 +1762,8 @@ namespace GingerCore.Actions
                 {
                     FC.Status = eStatus.Pending;
                 }
-
                 this.Status = Amdocs.Ginger.CoreNET.Execution.eRunStatus.Pending;
+                ResumeDirtyTracking();
             }
         }    // end of Reset
 

--- a/Ginger/GingerCoreCommon/Repository/RepositoryItemBase.cs
+++ b/Ginger/GingerCoreCommon/Repository/RepositoryItemBase.cs
@@ -1152,11 +1152,6 @@ namespace Amdocs.Ginger.Repository
 
         public void ResumeDirtyTracking()
         {
-            if (DirtyTracking == eDirtyTracking.NotStarted)
-            {
-                StartDirtyTracking();
-                return;
-            }
 
             if (DirtyTracking == eDirtyTracking.Paused)
             {


### PR DESCRIPTION
PR description - executing flow or runset would cause that entity to be marked as modified

also removed the start dirty tracking from resumeDirtyTracking method in RepositoryItemBase as I am the only one who uses these methods and when we execute Unit Tests, they should not be tracked but because of the logic that was in that method it started tracking the objects and it caused the unit tests to fail

Thank you for your contribution.
Before submitting this PR, please make sure:
- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is point to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for Existing Functionality
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
