### PR TITLE
Reports folder fix

### DIFF
--- a/Ginger/GingerCoreNET/Run/RunSetActions/RunSetActionHTMLReportSendEmailOperations.cs
+++ b/Ginger/GingerCoreNET/Run/RunSetActions/RunSetActionHTMLReportSendEmailOperations.cs
@@ -101,7 +101,13 @@ namespace Ginger.Run.RunSetActions
                     {
                         reportsResultFolder = Path.Combine(reportsResultFolder, $"{RunsetName}_{DateTimeStamp}");
                     }
-                                      
+                    
+                    //Check if report directory already exists, if yes, change the timestamp to latest plus the retry number in report path, retry for 5 times, rare scenario where it will take 5 retries 
+                    int numberOfRetry = 0;
+                    while (Directory.Exists(reportsResultFolder) && numberOfRetry <= 5)
+                    {
+                        reportsResultFolder = reportsResultFolder.Replace(DateTimeStamp, DateTime.UtcNow.ToString("yyyymmddhhmmssfff") + "_" + ++numberOfRetry);
+                    }
                     WebReportGenerator webReporterRunner = new WebReportGenerator();
                     liteDbRunSet = webReporterRunner.RunNewHtmlReport(reportsResultFolder, null, null, false);
                 }


### PR DESCRIPTION
Fixed HTML reports folder where it was accessing same folder when execution was triggered in quantities from eTDM



Thank you for your contribution.
Before submitting this PR, please make sure:
- [x] PR description and commit message should describe the changes done in this PR
- [x] Verify the PR is point to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [x] Latest Code from master or specific release branch is merged to your branch
- [x] No unwanted\commented\junk code is included
- [x] No new warning upon build solution
- [x] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [x] Sanity Tests are successfully executed for Existing Functionality
- [x] After creating pull request there should not be any conflicts
- [x] Resolve codacy comments
- [x] Builds and checks are passed before PR is sent for review
- [x] Resolve code review comments
