### PR TITLE
for PB driver

### DIFF
--- a/Ginger/GingerCore/Actions/UIAutomation/UIAComWrapperHelper.cs
+++ b/Ginger/GingerCore/Actions/UIAutomation/UIAComWrapperHelper.cs
@@ -4630,9 +4630,16 @@ namespace GingerCore.Drivers
         
         public override Bitmap GetAppWindowAsBitmap(AppWindow aw)  //******************        
         {
-            UIAuto.AutomationElement tempWindow = (UIAuto.AutomationElement)((UIAElementInfo)aw.RefObject).ElementObject;
-            Bitmap bmp = WindowToBitmap(tempWindow);
-            return bmp;
+            try
+            {
+                UIAuto.AutomationElement tempWindow = (UIAuto.AutomationElement)((UIAElementInfo)aw.RefObject).ElementObject;
+                Bitmap bmp = WindowToBitmap(tempWindow);
+                return bmp;
+            }
+            catch(Exception ex)
+            {
+                return null;
+            }
         }
 
         public override List<Bitmap> GetAppDialogAsBitmap(AppWindow aw)  ///********

--- a/Ginger/GingerCore/Drivers/PBDriver/PBDriver.cs
+++ b/Ginger/GingerCore/Drivers/PBDriver/PBDriver.cs
@@ -235,7 +235,8 @@ namespace GingerCore.Drivers.PBDriver
                                 foreach (AppWindow aw in list)
                                 {
                                     Bitmap bmp = mUIAutomationHelper.GetAppWindowAsBitmap(aw);
-                                    act.AddScreenShot(bmp);
+                                    if(bmp != null)
+                                        act.AddScreenShot(bmp); 
                                     bList = mUIAutomationHelper.GetAppDialogAsBitmap(aw);
                                     foreach (Bitmap tempbmp in bList)
                                     {

--- a/Ginger/GingerCore/Drivers/PBDriver/PBDriver.cs
+++ b/Ginger/GingerCore/Drivers/PBDriver/PBDriver.cs
@@ -235,8 +235,10 @@ namespace GingerCore.Drivers.PBDriver
                                 foreach (AppWindow aw in list)
                                 {
                                     Bitmap bmp = mUIAutomationHelper.GetAppWindowAsBitmap(aw);
-                                    if(bmp != null)
-                                        act.AddScreenShot(bmp); 
+                                    if (bmp != null)
+                                    {
+                                        act.AddScreenShot(bmp);
+                                    }
                                     bList = mUIAutomationHelper.GetAppDialogAsBitmap(aw);
                                     foreach (Bitmap tempbmp in bList)
                                     {


### PR DESCRIPTION
Earlier, if the screenshot for even one window was not captured, it resulted in discarding all screenshots for the particular action.
