### PR TITLE
FirefoxBrowserBugFix :- Bug 9578: Input Cutoff on FF Browser when Forms Use Input Masks

### DIFF
--- a/Ginger/GingerCoreNET/Drivers/CoreDrivers/Web/Selenium/SeleniumDriver.cs
+++ b/Ginger/GingerCoreNET/Drivers/CoreDrivers/Web/Selenium/SeleniumDriver.cs
@@ -7589,7 +7589,10 @@ namespace GingerCore.Drivers
                             e.Clear();
                             try
                             {
-                                e.SendKeys(GetKeyName(act.GetInputParamCalculatedValue("Value")));
+                                foreach (char i in act.GetInputParamCalculatedValue("Value"))
+                                {
+                                    e.SendKeys(GetKeyName(Char.ToString(i)));
+                                }
                             }
                             catch (InvalidOperationException ex)
                             {


### PR DESCRIPTION
Special Condition for Firefox Driver is updated for Set Value in Element Action as it was not working as expected.

Thank you for your contribution.
Before submitting this PR, please make sure:
- [x] PR description and commit message should describe the changes done in this PR
- [x] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [x] Latest Code from master or specific release branch is merged to your branch
- [x] No unwanted\commented\junk code is included
- [x] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [x] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [x] Verify that changes are compatible with all relevant browsers and platforms.
- [x] After creating pull request there should not be any conflicts
- [x] Resolve codacy comments
- [x] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Help Libray document is updated accordingly for Feature changes.
