### PR TITLE
Adding Get Console logs operation type for the Browser Action

### DIFF
--- a/Ginger/Ginger/Actions/ActionEditPages/ActBrowserElementEditPage.xaml.cs
+++ b/Ginger/Ginger/Actions/ActionEditPages/ActBrowserElementEditPage.xaml.cs
@@ -172,6 +172,12 @@ namespace Ginger.Actions
                     xUpdateNetworkUrlGridPnl.Visibility = System.Windows.Visibility.Visible;
                 }
             }
+            else if (mAct.ControlAction == ActBrowserElement.eControlAction.GetConsoleLog)
+            {
+                ResetPOMView();
+                xValueGrid.Visibility = System.Windows.Visibility.Visible;
+                xValueLabel.Content = "Text File Path:";
+            }
             else
             {
                 if (mAct.ControlAction == ActBrowserElement.eControlAction.InitializeBrowser)

--- a/Ginger/GingerCoreNET/ActionsLib/UI/Web/ActBrowserElement.cs
+++ b/Ginger/GingerCoreNET/ActionsLib/UI/Web/ActBrowserElement.cs
@@ -149,6 +149,8 @@ namespace GingerCore.Actions
             CloseAll,
             [EnumValueDescription("Get Browser Logs")]
             GetBrowserLog,
+            [EnumValueDescription("Get Console Logs")]
+            GetConsoleLog,
             [EnumValueDescription("Refresh")]
             Refresh,
             [EnumValueDescription("Navigate Back")]

--- a/Ginger/GingerCoreNET/Drivers/CoreDrivers/Web/Selenium/SeleniumDriver.cs
+++ b/Ginger/GingerCoreNET/Drivers/CoreDrivers/Web/Selenium/SeleniumDriver.cs
@@ -157,8 +157,8 @@ namespace GingerCore.Drivers
         public bool BrowserMinimized { get; set; }
 
         [UserConfigured]
-        [UserConfiguredDefault("")]
-        [UserConfiguredDescription("Set the minimum log level. Valid values are from 0 to 4: All = 0, Debug = 1, Info = 2, Warning = 3, Severe = 4")]
+        [UserConfiguredDefault("3")]
+        [UserConfiguredDescription("Set the minimum log level to read the console logs from the browser console. Valid values are from 0 to 4: All = 0, Debug = 1, Info = 2, Warning = 3, Severe = 4")]
         public string BrowserLogLevel { get; set; }
 
         [UserConfigured]
@@ -9642,7 +9642,7 @@ namespace GingerCore.Drivers
 
         private void SetBrowserLogLevel(DriverOptions options)
         {
-            if (!string.IsNullOrEmpty(BrowserLogLevel))
+            if (!BrowserLogLevel.Equals("3"))
             {
                 int numberLogLevel;
                 if (int.TryParse(BrowserLogLevel, out numberLogLevel))
@@ -9651,13 +9651,12 @@ namespace GingerCore.Drivers
                     {
                         options.SetLoggingPreference(OpenQA.Selenium.LogType.Browser, (OpenQA.Selenium.LogLevel)numberLogLevel);
                     }
-                    else throw new Exception("Please enter a valid number in the BrowserLogLevel parameter");
+                    else throw new Exception("Please enter a valid number in the BrowserLogLevel parameter in Agent Configuration");
                 }
                 else
                 {
-                    throw new Exception("Please enter a valid value in the BrowserLogLevel parameter");
+                    throw new Exception("Please enter a valid value in the BrowserLogLevel parameter in Agent Configurations");
                 }
-
             }
         }
 

--- a/Ginger/GingerCoreNET/Run/Platforms/PlatformsInfo/WebPlatformInfo.cs
+++ b/Ginger/GingerCoreNET/Run/Platforms/PlatformsInfo/WebPlatformInfo.cs
@@ -87,6 +87,7 @@ namespace GingerCore.Platforms.PlatformsInfo
             browserActElementList.Add(ActBrowserElement.eControlAction.GetMessageBoxText);
             browserActElementList.Add(ActBrowserElement.eControlAction.SetAlertBoxText);
             browserActElementList.Add(ActBrowserElement.eControlAction.GetBrowserLog);
+            browserActElementList.Add(ActBrowserElement.eControlAction.GetConsoleLog);
             browserActElementList.Add(ActBrowserElement.eControlAction.StartMonitoringNetworkLog);
             browserActElementList.Add(ActBrowserElement.eControlAction.GetNetworkLog);
             browserActElementList.Add(ActBrowserElement.eControlAction.StopMonitoringNetworkLog);


### PR DESCRIPTION
Thank you for your contribution.
Before submitting this PR, please make sure:
- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms. - Not working for the Firefox browser
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Help Libray document is updated accordingly for Feature changes.
------------------------------------------------------------------------------------------
I have added an enhancement for the browser action options in Ginger to get the browser console tab logs.

The new operation type in the browser action is called "Get Console Logs":
![](https://i.ibb.co/pKswn0R/unnamed.png)

![](https://i.ibb.co/9y15Ybw/image.png)

And his output is:

![](https://i.ibb.co/KbMvxNF/image-1.png)

![](https://i.ibb.co/BT8Rb9W/image-2.png)

![](https://i.ibb.co/J2JvHS0/image-3.png)

As you can see, there are different log levels in the console log tab: All = 0, Debug = 1, Info = 2, Warning = 3, and Severe = 4.
I added a parameter to configure the browser log level in the Configuration -> Agent (the default log level is 3 and is already built-in, so the BrowserLogLevel parameter is optional here):
![](https://i.ibb.co/4JF6dFf/image-4.png)

This functionality is not working on a Firefox agent per my implementation (with FireFoxOptions), and it seems it will not be fixed, according to Selenium:
https://stackoverflow.com/questions/51848372/getting-firefox-logs-in-c-sharp-using-selenium-throwing-nullreferenceexception
Note: The Get console logs operation is not throwing nullreferenceexception for firefox agent, it just execute the operation with an empty list on the output.

I saw other option to implement this with desiredCapabilities, but I didn't see Ginger using desiredCapabilities::
https://stackoverflow.com/questions/13204820/how-to-obtain-native-logger-in-selenium-webdriver
There is another solution to implement it with FirefoxProfile: 
https://www.selenium.dev/documentation/legacy/developers/tips/#getting-output-from-the-error-console-to-a-file
But I think I will need to write a different code for the Firefox agent and this solution will not be generic for all the web drivers.

An example of a test with a Chrome agent configured with the value of three in the BrowserLogLevel parameter (Warning -> Severe logs):
![](https://i.ibb.co/jDqqFML/unnamed-1.png)
As you can see, there are logs from levels 3 to 4 only.

I was also thinking to add an option to save these logs to an external file, so I have added a location path like this (I'm no sure how to add the "Browse" button here):
![](https://i.ibb.co/gVSjXWV/image-5.png)
![](https://i.ibb.co/grd3LR8/image-6.png)
![](https://i.ibb.co/FhGkSR7/image-7.png)

- Regarding unit test cases, I was trying to run the tests in the GingerCoreTest/UITests/WebDriverUnitTest.cs (I saw that all the operations related to the browser action are there), and I got this error message:
```bash
Failed GetConsoleLogTest
  Error Message:
   Class Initialization method UnitTests.UITests.WebDriverUnitTest.ClassInit threw exception. System.NullReferenceException: System.NullReferenceException: Object reference not set to an instance of an object..
  Stack Trace:
     at UnitTests.UITests.WebDriverUnitTest.ClassInit(TestContext context) in C:\Ginger\Ginger\GingerCoreTest\UITests\WebDriverUnitTestCase.cs:line 57 

Failed!  - Failed:     1, Passed:     0, Skipped:     0, Total:     1, Duration: 1 s - GingerCoreTest.dll (net6.0)
```

It is like that for all the test methods in this class.