### PR TITLE
Restore Env Parameter name to NameBeforeEdit

### DIFF
--- a/Ginger/Ginger/Environments/AppGeneralParamsPage.xaml.cs
+++ b/Ginger/Ginger/Environments/AppGeneralParamsPage.xaml.cs
@@ -69,10 +69,10 @@ namespace Ginger.Environments
                 if (changedParam.Name != changedParam.NameBeforeEdit)
                 {
                     //ask user if want us to update the parameter name in all BF's
-                    if (Reporter.ToUser(eUserMsgKey.ChangingEnvironmentParameterValue) == Amdocs.Ginger.Common.eUserMsgSelection.Yes)
-                    {
+                    if (Reporter.ToUser(eUserMsgKey.ChangingEnvironmentParameterValue) == eUserMsgSelection.Yes)
                         UpdateVariableNameChange(changedParam);
-                    }
+                    else
+                        changedParam.Name = changedParam.NameBeforeEdit; // Restore Variable Name
                 }
             }
             else if (e.Column.Header.ToString() == GeneralParam.Fields.Value)


### PR DESCRIPTION
while renaming the Env Parameter if user doesn't want to change the name then user can choose same by clicking on No when renaming popup comes up.
Thank you for your contribution.
Before submitting this PR, please make sure:
- [x] PR description and commit message should describe the changes done in this PR
- [x] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [x] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Help Libray document is updated accordingly for Feature changes.
