### PR TITLE
Fixed the "Read Text Between 2 Strings" in Image OCR Section Issue

### DIFF
--- a/Ginger/GingerCore/GingerOCR/GingerOcrOperations.cs
+++ b/Ginger/GingerCore/GingerOCR/GingerOcrOperations.cs
@@ -353,19 +353,26 @@ namespace GingerCore.GingerOCR
                             string lineTxt = iter.GetText(PageIteratorLevel.TextLine);
                             if (lineTxt.Contains(firstLabel))
                             {
-                                firstIndexOf = lineTxt.IndexOf(firstLabel) + firstLabel.Length;
+                                firstIndexOf = lineTxt.IndexOf(firstLabel);
+                                int startConcatIndex = lineTxt.IndexOf(firstLabel) + firstLabel.Length;
+
                                 if (lineTxt.Contains(secondLabel))
                                 {
                                     secondIndexOf = lineTxt.IndexOf(secondLabel);
-                                    resultTxt = lineTxt.Substring(firstIndexOf, secondIndexOf - firstIndexOf);
+
+                                    if (secondIndexOf == firstIndexOf) resultTxt = " ";
+
+                                    else resultTxt = lineTxt.Substring(startConcatIndex, secondIndexOf - startConcatIndex);
+
                                     return;
                                 }
                                 else
                                 {
-                                    resultTxt = string.Concat(resultTxt, lineTxt.Substring(firstIndexOf));
+                                    resultTxt = string.Concat(resultTxt, lineTxt.Substring(startConcatIndex));
                                     continue;
                                 }
                             }
+
                             if (firstIndexOf != -1)
                             {
                                 if (lineTxt.Contains(secondLabel))


### PR DESCRIPTION
Fixed the Read Between two strings in Image OCR Issue:
  Initially When the Start and End Strings are the same, the Application breaks
Solved the Issue by adding a if condition in ReadTextBetweenTwoLabels function of the GingerOCROperations

Thank you for your contribution.
Before submitting this PR, please make sure:
- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Help Libray document is updated accordingly for Feature changes.
