### PR TITLE
Bug fix/19270 no vertical scroll bar screenshot locators

### DIFF
--- a/Ginger/Ginger/UserControlsLib/UCElementDetails.xaml
+++ b/Ginger/Ginger/UserControlsLib/UCElementDetails.xaml
@@ -46,7 +46,6 @@
         <Grid.RowDefinitions>
             <RowDefinition x:Name="xTitleSection" Height="0"/>
             <RowDefinition Height="50*" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*"/>
@@ -57,9 +56,9 @@
             <TextBlock x:Name="xSelectedElementTextBlock" Text="Selected Element" VerticalAlignment="Center" Margin="5,0,0,0" Foreground="{StaticResource $Color_DarkBlue}" FontWeight="Bold" FontSize="15" />
         </StackPanel>-->
 
-        <Frame x:Name="xElementScreenShotFrameTop" Visibility="Collapsed" Grid.Column="0" Grid.Row="1" Margin="5,0,0,0" MaxHeight="100" VerticalAlignment="Top"></Frame>
+        <Frame x:Name="xElementScreenShotFrameTop" Visibility="Collapsed" Grid.Column="0" Grid.Row="0" Margin="5,0,0,0" MaxHeight="100" VerticalAlignment="Top"></Frame>
 
-        <TabControl x:Name="xElementDetailsTabs" Grid.Row="2" Grid.Column="0" Margin="5,5,0,0" HorizontalAlignment="Stretch" SelectionChanged="ElementDetailsTabs_SelectionChanged" Height="Auto" >
+        <TabControl x:Name="xElementDetailsTabs" Grid.Row="1" Grid.Column="0" Margin="5,5,0,0" HorizontalAlignment="Stretch" SelectionChanged="ElementDetailsTabs_SelectionChanged" Height="Auto" >
             <TabControl.Resources>
                 <Style TargetType="{x:Type TabItem}">
                     <Setter Property="Background" Value="{StaticResource $BackgroundColor_LightGray}"/>
@@ -152,6 +151,6 @@
             </TabItem>
         </TabControl>
 
-        <Frame x:Name="xElementScreenShotFrame" Grid.Column="1" Grid.Row="2" Margin="5,25,5,0" Height="200" VerticalAlignment="Top"></Frame>
+        <Frame x:Name="xElementScreenShotFrame" Grid.Column="1" Grid.Row="1" Margin="5,25,5,0" Height="200" VerticalAlignment="Top"></Frame>
     </Grid>
 </UserControl>


### PR DESCRIPTION
On Automate Page when user tries to populate locators using Screenshot feature, then in locators tab the vertical scroll bar was not getting enabled.
Thank you for your contribution.
Before submitting this PR, please make sure:
- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Help Libray document is updated accordingly for Feature changes.
