### PR TITLE
Provided the decrypted Password in the Read Text Between 2 Strings Method Call

### DIFF
--- a/Ginger/GingerCore/ActOcr.cs
+++ b/Ginger/GingerCore/ActOcr.cs
@@ -359,7 +359,7 @@ namespace GingerCore
                 case eActOcrPdfOperations.ReadTextBetweenTwoStrings:
                     string err = string.Empty;
                     resultText = GingerOcrOperations.ReadTextBetweenLabelsPdf(ValueExpression.Calculate(OcrFilePath), ValueExpression.Calculate(FirstString),
-                        ValueExpression.Calculate(SecondString), ValueExpression.Calculate(PageNumber), (int)SelectedOcrDPIOperation,ref err,ValueExpression.Calculate(OcrPassword));
+                        ValueExpression.Calculate(SecondString), ValueExpression.Calculate(PageNumber), (int)SelectedOcrDPIOperation,ref err,decryptedPassword);
                     if (!string.IsNullOrEmpty(resultText))
                     {
                         ProcessOutput(resultText);


### PR DESCRIPTION
Decrypted Password instead of an Encrypted one required for the ReadTextBetweenTwoStrings function to successfully run.

Thank you for your contribution.
Before submitting this PR, please make sure:
- [x] PR description and commit message should describe the changes done in this PR
- [x] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [x] Latest Code from master or specific release branch is merged to your branch
- [x] No unwanted\commented\junk code is included
- [x] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [x] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Help Libray document is updated accordingly for Feature changes.
