### PR TITLE
Fixed the Database Operation Type and Input Type Issue in Database Ac…

### DIFF
--- a/Ginger/Ginger/Actions/ActionEditPages/ValidationDBPage.xaml.cs
+++ b/Ginger/Ginger/Actions/ActionEditPages/ValidationDBPage.xaml.cs
@@ -62,14 +62,14 @@ namespace Ginger.Actions
             {
                 mAct.AddOrUpdateInputParamValue("SQL", mAct.GetInputParamValue("Value"));
             }
-
+             
             FillAppComboBox();
 
             //New UI Controls:
             //Query Type selection radio button :
             QueryTypeRadioButton.Init(typeof(ActDBValidation.eQueryType), SqlSelection, mAct.GetOrCreateInputParam(ActDBValidation.Fields.QueryTypeRadioButton, ActDBValidation.eQueryType.FreeSQL.ToString()), QueryType_SelectionChanged);
             checkQueryType();
-
+            
             //Free SQL
             //needs to be unmarked when fixed VE issue
             SQLUCValueExpression.Init(Context.GetAsContext(mAct.Context), mAct.GetOrCreateInputParam(ActDBValidation.Fields.SQL));
@@ -483,9 +483,11 @@ namespace Ginger.Actions
 
         private void SetVisibleControlsForAction()
         {
+
+            // Whenever no Database Operation is selected then the Input Type and the Radio buttons related to the input type should be hidden.
             if (ValidationCfgComboBox.SelectedItem == null)
             {
-                RadioButtonsSection.Visibility = Visibility.Visible;
+                RadioButtonsSection.Visibility = Visibility.Collapsed;
                 FreeSQLStackPanel.Visibility = Visibility.Collapsed;
                 SqlFile.Visibility = Visibility.Collapsed;
                 DoCommit.Visibility = Visibility.Collapsed;
@@ -538,7 +540,6 @@ namespace Ginger.Actions
                         lblWhere.Visibility = Visibility.Hidden;
                         TableColWhereStackPanel.Height = 40;
                         DoCommit.Visibility = Visibility.Collapsed;
-                        FreeSQLStackPanel.Visibility = Visibility.Collapsed;
                         DoUpdate.Visibility = Visibility.Visible;
                         RadioButtonsSection.Visibility = Visibility.Collapsed;
                         UpdateDbParametersGrid.Visibility = Visibility.Visible;
@@ -549,14 +550,18 @@ namespace Ginger.Actions
                     }
                     else
                     {
-                        FreeSQLStackPanel.Visibility = Visibility.Visible;
+                        string queryTypeRadioValue = mAct.GetInputParamValue(ActDBValidation.Fields.QueryTypeRadioButton);
+                        if (queryTypeRadioValue == ActDBValidation.eQueryType.FreeSQL.ToString())
+                        {
+                            FreeSQLStackPanel.Visibility = Visibility.Visible;
+                            SqlFile.Visibility = Visibility.Collapsed;
+                        }
                         TableColWhereStackPanel.Visibility = Visibility.Collapsed;
                         txtWhere.Visibility = Visibility.Visible;
                         lblWhere.Visibility = Visibility.Visible;
                         TableColWhereStackPanel.Height = 244;
                         DoCommit.Visibility = Visibility.Visible;
                         DoUpdate.Visibility = Visibility.Collapsed;
-                        FreeSQLStackPanel.Visibility = Visibility.Visible;
                         RadioButtonsSection.Visibility = Visibility.Visible;
                     }
                     break;


### PR DESCRIPTION

The Issue: When you set DB Operation Type as Update DB and select Input Type as 'From File' and then go to the previous Action using the up arrow and then come back to the Database Action both the Folder input as well Free SQL Input is visible.

 Whenever you go back and forth around an action, the constructor is called  and the constructor of "Database Action" Action
has a function which allows the visibility of Free SQL Input regardless of what Input Type is actually selected.

The code change intends to handle the above error.  


Thank you for your contribution.
Before submitting this PR, please make sure:
- [x] PR description and commit message should describe the changes done in this PR
- [x] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [x] Latest Code from master or specific release branch is merged to your branch
- [x] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [x] Code Summary\Comments are added to my code which explains what my code is doing
- [x] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Help Libray document is updated accordingly for Feature changes.
