### PR TITLE
Changed the way null columns were viewed in excel

### DIFF
--- a/Ginger/GingerCoreNET/Run/Excels/ExcelNPOIOperations.cs
+++ b/Ginger/GingerCoreNET/Run/Excels/ExcelNPOIOperations.cs
@@ -56,12 +56,11 @@ namespace Amdocs.Ginger.CoreNET.ActionsLib
                  initialColNumber -> is used to locate the first column number of the first header column
                  */
                 int initialColNumber = -1;
-                int blankColNumbers = 0;
-                SetHeaderColumns(headerRow , ref initialColNumber, dtExcelTable, ref blankColNumbers);
+                SetHeaderColumns(headerRow , ref initialColNumber, dtExcelTable);
                 /*
                  intialColNumber is used to also locate where to start and end the reading of the row data. 
                  */
-                SetRowsForDataTable(sheet , dtExcelTable , initialColNumber, rowHeaderNumber, rowLimit , blankColNumbers);
+                SetRowsForDataTable(sheet , dtExcelTable , initialColNumber, rowHeaderNumber, rowLimit);
                 return dtExcelTable;
             }
             catch (Exception ex)
@@ -400,7 +399,7 @@ namespace Amdocs.Ginger.CoreNET.ActionsLib
         }
 
 
-        private void SetHeaderColumns(IRow headerRow, ref int initialColNumber, DataTable dtExcelTable, ref int blankColNumbers )
+        private void SetHeaderColumns(IRow headerRow, ref int initialColNumber, DataTable dtExcelTable )
         {
             int colCount = headerRow.LastCellNum;
             for (var c = 0; c < colCount; c++)
@@ -416,7 +415,7 @@ namespace Amdocs.Ginger.CoreNET.ActionsLib
                 }
                 else
                 {
-                    blankColNumbers++;
+                    dtExcelTable.Columns.Add("Col " + c);
                 }
             }
         }
@@ -429,24 +428,19 @@ namespace Amdocs.Ginger.CoreNET.ActionsLib
         /// <param name="startRowNumber">Used to locate the first Row Number from where the row data begins</param>
         /// <param name="rowLimit">If the 'View Data / View Filtered Data' is selected on the Excel Action Page, the rowLimit is set , which means the user will only see AT MOST 'rowLimit' number of rows apart from the Column Header row </param>
 
-        private void SetRowsForDataTable(ISheet sheet, DataTable dtExcelTable, int initialColNumber, int startRowNumber, int rowLimit, int blankColNumbers)
+        private void SetRowsForDataTable(ISheet sheet, DataTable dtExcelTable, int initialColNumber, int startRowNumber, int rowLimit)
         {
             var currentRowNumber = startRowNumber;
             var currentRow = sheet.GetRow(currentRowNumber);
             while ( HasDataTableReachedRowLimit(currentRow , rowLimit , startRowNumber, currentRowNumber))
             {
                 var dr = dtExcelTable.NewRow();
-                int currentBlankRows = 0;
-                for (var currentColNumber = initialColNumber; currentColNumber < (initialColNumber + dr.ItemArray.Length + blankColNumbers); currentColNumber++)
+                for (var currentColNumber = initialColNumber; currentColNumber < (initialColNumber + dr.ItemArray.Length); currentColNumber++)
                 {
                     var cell = currentRow.GetCell(currentColNumber);
                     if (cell != null)
                     {
-                        dr[currentColNumber - initialColNumber - currentBlankRows] = GetCellValue(cell, cell.CellType);
-                    }
-                    else
-                    {
-                        currentBlankRows++;
+                        dr[currentColNumber - initialColNumber] = GetCellValue(cell, cell.CellType);
                     }
                 }
                 dtExcelTable.Rows.Add(dr);


### PR DESCRIPTION
Bug: 
Misrepresentation of null columns
The 'Read Excel' operation did not take account of empty columns, which resulted in the misrepresentation of Excel sheets.


Fix:
Represented the empty Table Column Headers as 'Col <Column number>' . 
This fix mitigated the issue.



Thank you for your contribution.
Before submitting this PR, please make sure:
- [x] PR description and commit message should describe the changes done in this PR
- [x] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [x] Latest Code from master or specific release branch is merged to your branch
- [x] No unwanted\commented\junk code is included
- [x] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Help Libray document is updated accordingly for Feature changes.
