### PR TITLE
Windows with no tile were not getting listed in Live Spy/Explorer.

### DIFF
--- a/Ginger/GingerCore/Actions/UIAutomation/UIAComWrapperHelper.cs
+++ b/Ginger/GingerCore/Actions/UIAutomation/UIAComWrapperHelper.cs
@@ -468,7 +468,8 @@ namespace GingerCore.Drivers
 
                         //list All Windows except PB windows - FNW
 
-                        if (!window.Current.ClassName.StartsWith("FNW"))
+                        bool isPowerBuilderWindow = window.Current.ClassName.StartsWith("FNW");
+                        if (!isPowerBuilderWindow)
                         {
                             string WindowTitle = GetWindowInfo(window);
                             if (String.IsNullOrEmpty(WindowTitle))
@@ -481,12 +482,15 @@ namespace GingerCore.Drivers
                                 Process p = Process.GetProcessById(window.Current.ProcessId);
                                 if (p.ProcessName == "AcroRd32")
                                 {
-                                    WindowTitle = Process.GetProcessById(window.Current.ProcessId).MainWindowTitle;
+                                    WindowTitle = p.MainWindowTitle;
+                                }
+                                else if (p.ProcessName != "explorer" || p.ProcessName != "OUTLOOK")
+                                {
+                                    WindowTitle = p.ProcessName;
                                 }
                             }
                             if (!String.IsNullOrEmpty(WindowTitle))
                             {
-
                                 list.Add(GetAppWinodowForElement(window, WindowTitle, AppWindow.eWindowType.Windows));
                             }
 


### PR DESCRIPTION
For Windows based applications, if the Window doesn't have Title then we were not listing them in Live Spy or Explorer utility of Ginger.
Fixed it by assigning the Processname where there is not Title.

Thank you for your contribution.
Before submitting this PR, please make sure:

- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve all Codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Update the Help Library document to match any feature changes
