### PR TITLE
BugFix - 39592 - Screenshot Not Available When Tab Closed Manually

### DIFF
--- a/Ginger/GingerCoreNET/Drivers/CoreDrivers/Web/Playwright/PlaywrightBrowserTab.cs
+++ b/Ginger/GingerCoreNET/Drivers/CoreDrivers/Web/Playwright/PlaywrightBrowserTab.cs
@@ -51,6 +51,18 @@ namespace Amdocs.Ginger.CoreNET.Drivers.CoreDrivers.Web.Playwright
             _onTabClose = onTabClose;
             _currentFrame = _playwrightPage.MainFrame;
             _playwrightPage.Console += OnConsoleMessage;
+            _playwrightPage.Close += OnPlaywrightPageClose;
+        }
+
+        private void RemoveEventHandlers()
+        {
+            _playwrightPage.Console -= OnConsoleMessage;
+            _playwrightPage.Close -= OnPlaywrightPageClose;
+        }
+
+        private void OnPlaywrightPageClose(object? sender, IPlaywrightPage e)
+        {
+            _ = CloseAsync();
         }
 
         private void OnConsoleMessage(object? sender, IConsoleMessage e)
@@ -353,7 +365,8 @@ namespace Amdocs.Ginger.CoreNET.Drivers.CoreDrivers.Web.Playwright
             _isClosed = true;
             //_playwrightPage.Dialog -= OnDialog;
             await _playwrightPage.CloseAsync();
-            await _onTabClose.Invoke(closedTab: this);
+            RemoveEventHandlers();
+            await _onTabClose(closedTab: this);
         }
 
         private void ThrowIfClosed()


### PR DESCRIPTION
Thank you for your contribution.
Before submitting this PR, please make sure:

- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve all Codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Update the Help Library document to match any feature changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced browser tab management by adding event handlers for page close events.

- **Bug Fixes**
  - Improved stability by ensuring event handlers are properly removed when closing the browser tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->