### PR TITLE
D40482_D40532_The double-click event for ApplicationPlatform selectio…

### DIFF
--- a/Ginger/Ginger/ALM/RQM/RQMImportPlanByIdPage.xaml.cs
+++ b/Ginger/Ginger/ALM/RQM/RQMImportPlanByIdPage.xaml.cs
@@ -75,6 +75,10 @@ namespace Ginger.ALM.RQM
             testPlanId = txtTestPlanId.Text;
             if (testPlanId != "")
             {
+                if(testPlanId.Contains("RQMID="))
+                {
+                    testPlanId = testPlanId.Replace("RQMID=", string.Empty);
+                }
                 RQMTestPlan testPlan = RQMConnect.Instance.GetRQMTestPlanByIdByProject(ALMCore.DefaultAlmConfig.ALMServerURL, ALMCore.DefaultAlmConfig.ALMUserName,
                      ALMCore.DefaultAlmConfig.ALMPassword, ALMCore.DefaultAlmConfig.ALMProjectName, testPlanId);
                 ImportTestPlan(testPlan);

--- a/Ginger/Ginger/SolutionWindows/AddApplicationPage.xaml.cs
+++ b/Ginger/Ginger/SolutionWindows/AddApplicationPage.xaml.cs
@@ -71,7 +71,6 @@ namespace Ginger.SolutionWindows
             APs.Add(new ApplicationPlatform() { AppName = "MyWindowsApp", Platform = ePlatformType.Windows, Description = "Windows Application" });
             APs.Add(new ApplicationPlatform() { AppName = "MyPowerBuilderApp", Platform = ePlatformType.PowerBuilder, Description = "Power Builder Application" });
             SelectApplicationGrid.DataSourceList = APs;
-            SelectApplicationGrid.RowDoubleClick += SelectApplicationGrid_RowDoubleClick;
             SelectApplicationGrid.SearchVisibility = Visibility.Collapsed;
         }
 
@@ -234,12 +233,6 @@ namespace Ginger.SolutionWindows
 
             agent.AgentOperations.InitDriverConfigs();
             WorkSpace.Instance.SolutionRepository.AddRepositoryItem(agent);
-        }
-
-        private void SelectApplicationGrid_RowDoubleClick(object sender, EventArgs e)
-        {
-            OKButton_Click(sender, null);
-            _pageGenericWin.Close();
         }
     }
 }


### PR DESCRIPTION
…n has been removed, and the option to import AlmTest Plan by ID has been enhanced for Ginger, specifically using the ExternalID.

Thank you for your contribution.
Before submitting this PR, please make sure:

- [x] PR description and commit message should describe the changes done in this PR
- [x] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [x] Latest Code from master or specific release branch is merged to your branch
- [x] No unwanted\commented\junk code is included
- [x] No new warning upon build solution
- [x] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [x] Verify that changes are compatible with all relevant browsers and platforms.
- [x] After creating pull request there should not be any conflicts
- [ ] Resolve all Codacy comments
- [x] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Update the Help Library document to match any feature changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of `testPlanId` to correctly process IDs containing "RQMID=" in the RQM Import Plan.

- **Refactor**
  - Removed the double-click event handler from the application selection grid to streamline the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->