### PR TITLE
BugFix - 43100 - Disabled finish button on "Import POM from Katalon Object Repository Wizard"

### DIFF
--- a/Ginger/Ginger/External/Katalon/ImportPOMFromObjectRepositoryWizardPage.xaml.cs
+++ b/Ginger/Ginger/External/Katalon/ImportPOMFromObjectRepositoryWizardPage.xaml.cs
@@ -177,6 +177,7 @@ namespace Ginger.External.Katalon
             switch (e.EventType)
             {
                 case EventType.Active:
+                    _wizard.mWizardWindow?.SetFinishButtonEnabled(false);
                     _ = ImportPOMsAsync();
                     break;
                 case EventType.LeavingForNextPage:

--- a/Ginger/Ginger/External/Katalon/ImportPOMSummaryWizardPage.xaml.cs
+++ b/Ginger/Ginger/External/Katalon/ImportPOMSummaryWizardPage.xaml.cs
@@ -31,7 +31,11 @@ namespace Ginger.External.Katalon
 
         public void WizardEvent(WizardEventArgs e)
         {
-            if (e.EventType == EventType.Prev && _wizard.GetCurrentPage().Page == this)
+            if (e.EventType == EventType.Active)
+            {
+                _wizard.mWizardWindow?.SetFinishButtonEnabled(true);
+            }
+            else if (e.EventType == EventType.Prev && _wizard.GetCurrentPage().Page == this)
             {
                 e.CancelEvent = true;
             }

--- a/Ginger/Ginger/External/Katalon/SelectObjectRepositoryFolderWizardPage.xaml.cs
+++ b/Ginger/Ginger/External/Katalon/SelectObjectRepositoryFolderWizardPage.xaml.cs
@@ -32,6 +32,9 @@ namespace Ginger.External.Katalon
         {
             switch (e.EventType)
             {
+                case EventType.Active:
+                    _wizard.mWizardWindow?.SetFinishButtonEnabled(false);
+                    break;
                 case EventType.LeavingForNextPage:
                     if (string.IsNullOrWhiteSpace(_wizard.SelectedDirectory))
                     {


### PR DESCRIPTION
Thank you for your contribution.
Before submitting this PR, please make sure:

- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve all Codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Update the Help Library document to match any feature changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced control flow in the import wizard by disabling the finish button when the wizard is active.
	- Improved error handling during the import process with feedback on import failures.
	- Immediate feedback for users when the import summary page becomes active.

- **Bug Fixes**
	- Adjusted conditions for enabling the finish button based on the wizard event type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->