### PR TITLE
BugFix - 44116 - Disabled Prev Button in Katalon Import POM Wizard

### DIFF
--- a/Ginger/Ginger/External/Katalon/ImportKatalonObjectRepositoryWizard.cs
+++ b/Ginger/Ginger/External/Katalon/ImportKatalonObjectRepositoryWizard.cs
@@ -47,6 +47,7 @@ namespace Ginger.External.Katalon
             _importTargetDirectory = importTargetDirectory;
             POMViewModels = [];
             _selectedDirectory = string.Empty;
+            DisableBackBtnOnLastPage = true;
             AddPages();
         }
 


### PR DESCRIPTION
Thank you for your contribution.
Before submitting this PR, please make sure:

- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve all Codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Update the Help Library document to match any feature changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The back button is now disabled on the last page of the Import Katalon Object Repository Wizard, enhancing user experience during the import process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->