### PR TITLE
BugFix - 44384 - Updating Single POM ignores missing category

### DIFF
--- a/Ginger/GingerCoreNET/Application Models/CategoryMergingUtils.cs
+++ b/Ginger/GingerCoreNET/Application Models/CategoryMergingUtils.cs
@@ -23,8 +23,19 @@ using System.Linq;
 
 namespace Amdocs.Ginger.CoreNET.Application_Models
 {
+    /// <summary>
+    /// Utility class for merging collections while preserving items from categories not present in the new data.
+    /// </summary>
     public static class CategoryMergingUtils
     {
+        /// <summary>
+        /// Merges two collections by preserving items from the existing collection whose categories are not present in the latest collection.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the collections.</typeparam>
+        /// <param name="existing">The existing collection to merge from.</param>
+        /// <param name="latest">The latest collection to merge with.</param>
+        /// <param name="categorySelector">A function to extract the category from each item.</param>
+        /// <returns>A new collection containing all items from the latest collection and preserved items from the existing collection.</returns>
         public static ObservableList<T> MergeByCategory<T>(
         ObservableList<T> existing,
         ObservableList<T> latest,

--- a/Ginger/GingerCoreNET/Application Models/CategoryMergingUtils.cs
+++ b/Ginger/GingerCoreNET/Application Models/CategoryMergingUtils.cs
@@ -1,0 +1,55 @@
+﻿#region License
+/*
+Copyright © 2014-2024 European Support Limited
+
+Licensed under the Apache License, Version 2.0 (the "License")
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at 
+
+http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License. 
+*/
+#endregion
+
+using Amdocs.Ginger.Common;
+using Amdocs.Ginger.Repository;
+using System;
+using System.Linq;
+
+namespace Amdocs.Ginger.CoreNET.Application_Models
+{
+    public static class CategoryMergingUtils
+    {
+        public static ObservableList<T> MergeByCategory<T>(
+        ObservableList<T> existing,
+        ObservableList<T> latest,
+        Func<T, ePomElementCategory?> categorySelector)
+        {
+            var existingCategories = existing?
+                .Where(x => categorySelector(x).HasValue)
+                .Select(x => categorySelector(x).Value)
+                .Distinct() ?? [];
+
+            var newCategories = latest?
+                .Where(x => categorySelector(x).HasValue)
+                .Select(x => categorySelector(x).Value)
+                .Distinct() ?? [];
+
+            var missingCategories = existingCategories
+                .Where(c => !newCategories.Contains(c))
+                .ToArray();
+
+            var preservedItems = existing?
+                .Where(x => categorySelector(x).HasValue &&
+                       missingCategories.Contains(categorySelector(x).Value))
+                .ToArray() ?? [];
+
+            return [.. (latest ?? []), .. preservedItems];
+        }
+    }
+}

--- a/Ginger/GingerCoreNET/Application Models/Execution/POM/POMExecutionUtils.cs
+++ b/Ginger/GingerCoreNET/Application Models/Execution/POM/POMExecutionUtils.cs
@@ -307,7 +307,36 @@ namespace Amdocs.Ginger.CoreNET.Application_Models.Execution.POM
                     {
                         if (deltaInfo.DeltaStatus == eDeltaStatus.Changed)
                         {
-                            elementInfo.Properties = deltaInfo.ElementInfo.Properties;
+
+                            //Merge Both Category Properties
+                            IEnumerable<ePomElementCategory> existingPropertiesCategories = [];
+                            if (elementInfo.Properties != null)
+                            {
+                                existingPropertiesCategories = elementInfo.Properties
+                                .Where(l => l.Category.HasValue)
+                                .Select(l => l.Category.Value)
+                                .Distinct()
+                                .ToArray();
+                            }
+                            IEnumerable<ePomElementCategory> newPropertiesCategories = [];
+                            if (deltaInfo.ElementInfo.Properties != null)
+                            {
+                                newPropertiesCategories = deltaInfo.ElementInfo.Properties
+                                .Where(l => l.Category.HasValue)
+                                .Select(l => l.Category.Value)
+                                .Distinct()
+                                .ToArray();
+                            }
+
+                            IEnumerable<ePomElementCategory> missingCategoriesInNewProperties = existingPropertiesCategories
+                                .Where(c => !newPropertiesCategories.Contains(c))
+                                .ToArray();
+                            IEnumerable<ControlProperty> existingPropertiesWithCategoryMissingInNew = elementInfo.Properties
+                                .Where(l => l.Category.HasValue && missingCategoriesInNewProperties.Contains(l.Category.Value))
+                                .ToArray();
+                            elementInfo.Properties = [.. deltaInfo.ElementInfo.Properties, .. existingPropertiesWithCategoryMissingInNew];
+
+                            //Merge Both Category Locators
                             IEnumerable<ePomElementCategory> existingLocatorCategories = [];
                             if (elementInfo.Locators != null)
                             {

--- a/Ginger/GingerCoreNET/Application Models/Execution/POM/POMExecutionUtils.cs
+++ b/Ginger/GingerCoreNET/Application Models/Execution/POM/POMExecutionUtils.cs
@@ -308,7 +308,31 @@ namespace Amdocs.Ginger.CoreNET.Application_Models.Execution.POM
                         if (deltaInfo.DeltaStatus == eDeltaStatus.Changed)
                         {
                             elementInfo.Properties = deltaInfo.ElementInfo.Properties;
-                            elementInfo.Locators = deltaInfo.ElementInfo.Locators;
+                            IEnumerable<ePomElementCategory> existingLocatorCategories = [];
+                            if (elementInfo.Locators != null)
+                            {
+                                existingLocatorCategories = elementInfo.Locators
+                                .Where(l => l.Category.HasValue)
+                                .Select(l => l.Category.Value)
+                                .Distinct()
+                                .ToArray();
+                            }
+                            IEnumerable<ePomElementCategory> newLocatorCategories = [];
+                            if (deltaInfo.ElementInfo.Locators != null)
+                            {
+                                newLocatorCategories = deltaInfo.ElementInfo.Locators
+                                .Where(l => l.Category.HasValue)
+                                .Select(l => l.Category.Value)
+                                .Distinct()
+                                .ToArray();
+                            }
+                            IEnumerable<ePomElementCategory> missingCategoriesInNewLocators = existingLocatorCategories
+                                .Where(c => !newLocatorCategories.Contains(c))
+                                .ToArray();
+                            IEnumerable<ElementLocator> existingLocatorsWithCategoryMissingInNew = elementInfo.Locators
+                                .Where(l => l.Category.HasValue && missingCategoriesInNewLocators.Contains(l.Category.Value))
+                                .ToArray();
+                            elementInfo.Locators = [.. deltaInfo.ElementInfo.Locators, .. existingLocatorsWithCategoryMissingInNew];
                             elementInfo.LastUpdatedTime = DateTime.Now.ToString();
                             elementInfo.SelfHealingInfo = SelfHealingInfoEnum.ElementModified;
                         }

--- a/Ginger/GingerCoreNET/NewSelfHealing/ElementPropertyMatcher.cs
+++ b/Ginger/GingerCoreNET/NewSelfHealing/ElementPropertyMatcher.cs
@@ -1,10 +1,9 @@
 ﻿using Amdocs.Ginger.Common.UIElement;
+using Amdocs.Ginger.Repository;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 #nullable enable
 namespace Amdocs.Ginger.CoreNET.NewSelfHealing
@@ -20,6 +19,7 @@ namespace Amdocs.Ginger.CoreNET.NewSelfHealing
 
         internal virtual double Match(ElementInfo expected, ElementInfo actual)
         {
+            ePomElementCategory? expectedCategory = expected.Properties.FirstOrDefault().Category.Value;
             if (expected == null)
             {
                 throw new ArgumentNullException(paramName: nameof(expected));
@@ -31,8 +31,8 @@ namespace Amdocs.Ginger.CoreNET.NewSelfHealing
 
             _logger?.LogTrace("matching expected element({expectedElementName}-{expectedElementId}) with actual element({actualElementName}-{actualElementId})", expected.ElementName, expected.Guid, actual.ElementName, actual.Guid);
 
-            List<ControlProperty> expectedProperties = new((expected.Properties ?? []).Where(p => p != null));
-            List<ControlProperty> actualProperties = new((actual.Properties ?? []).Where(p => p != null));
+            List<ControlProperty> expectedProperties = new((expected.Properties ?? []).Where(p => p != null && p.Category.Equals(expectedCategory)));
+            List<ControlProperty> actualProperties = new((actual.Properties ?? []).Where(p => p != null && p.Category.Equals(expectedCategory)));
 
             double actualScore = 0;
             double totalScore = 0;

--- a/Ginger/GingerCoreNET/NewSelfHealing/ElementPropertyMatcher.cs
+++ b/Ginger/GingerCoreNET/NewSelfHealing/ElementPropertyMatcher.cs
@@ -17,9 +17,9 @@ namespace Amdocs.Ginger.CoreNET.NewSelfHealing
             _logger = logger;
         }
 
-        internal virtual double Match(ElementInfo expected, ElementInfo actual)
+        internal virtual double Match(ElementInfo expected, ElementInfo actual, ePomElementCategory? expectedCategory)
         {
-            ePomElementCategory? expectedCategory = expected.Properties.FirstOrDefault().Category.Value;
+
             if (expected == null)
             {
                 throw new ArgumentNullException(paramName: nameof(expected));
@@ -31,8 +31,8 @@ namespace Amdocs.Ginger.CoreNET.NewSelfHealing
 
             _logger?.LogTrace("matching expected element({expectedElementName}-{expectedElementId}) with actual element({actualElementName}-{actualElementId})", expected.ElementName, expected.Guid, actual.ElementName, actual.Guid);
 
-            List<ControlProperty> expectedProperties = new((expected.Properties ?? []).Where(p => p != null && p.Category.Equals(expectedCategory)));
-            List<ControlProperty> actualProperties = new((actual.Properties ?? []).Where(p => p != null && p.Category.Equals(expectedCategory)));
+            List<ControlProperty> expectedProperties = expectedCategory != null ? new((expected.Properties ?? []).Where(p => p != null && p.Category != null && p.Category.Equals(expectedCategory))) : new((expected.Properties ?? []).Where(p => p != null));
+            List<ControlProperty> actualProperties = expectedCategory != null ? new((actual.Properties ?? []).Where(p => p != null && p.Category != null && p.Category.Equals(expectedCategory))) : new((actual.Properties ?? []).Where(p => p != null));
 
             double actualScore = 0;
             double totalScore = 0;

--- a/Ginger/GingerCoreNET/NewSelfHealing/ElementPropertyMatcher.cs
+++ b/Ginger/GingerCoreNET/NewSelfHealing/ElementPropertyMatcher.cs
@@ -17,6 +17,13 @@ namespace Amdocs.Ginger.CoreNET.NewSelfHealing
             _logger = logger;
         }
 
+        /// <summary>
+        /// Matches two elements based on their properties, optionally filtering by category.
+        /// </summary>
+        /// <param name="expected">The expected element to match against.</param>
+        /// <param name="actual">The actual element to compare.</param>
+        /// <param name="expectedCategory">Optional category to filter properties by during matching.</param>
+        /// <returns>A score between 0 and 1 indicating the match quality.</returns>
         internal virtual double Match(ElementInfo expected, ElementInfo actual, ePomElementCategory? expectedCategory)
         {
 


### PR DESCRIPTION
Thank you for your contribution.
Before submitting this PR, please make sure:

- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve all Codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Update the Help Library document to match any feature changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced logic for preserving relevant properties and locators during the self-healing process, ensuring that updates do not inadvertently delete important information.
	- Refined delta comparison process to prevent deletion of properties and locators that match expected categories.
  
- **New Features**
	- Introduced category-based merging logic for properties and locators to improve self-healing capabilities.
	- Added a new utility for merging lists based on specified categories, enhancing the accuracy of element matching.
	- Updated matching logic to consider element categories, improving the accuracy of property comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->