### PR TITLE
Implemented Missing Where operators for Table Element Action in Power…

### DIFF
--- a/Ginger/GingerCore/Actions/UIAutomation/UIAComWrapperHelper.cs
+++ b/Ginger/GingerCore/Actions/UIAutomation/UIAComWrapperHelper.cs
@@ -5281,53 +5281,112 @@ namespace GingerCore.Drivers
             return null;
         }
 
-        public int GetRowNumFromCollection(UIAuto.AutomationElement[] AECollection, ActTableElement.eRunColPropertyValue propVal, ActTableElement.eRunColOperator WhereOperator, string value)
+        public int GetMatchingRowNumFromCollection(UIAuto.AutomationElement[] AECollection, ActTableElement actGrid)
         {
-            UIAuto.AutomationElement targetElement;
-            string controlValue = "";
-            if (ActTableElement.eRunColOperator.Equals == WhereOperator)
-            {
-                for (int i = 0; i < AECollection.Length; i++)
-                {
-                    targetElement = AECollection[i];
-                    if (propVal == ActTableElement.eRunColPropertyValue.Text)
-                    {
-                        controlValue = GetControlText(targetElement);
-                    }
-                    else if (propVal == ActTableElement.eRunColPropertyValue.Value)
-                    {
-                        controlValue = GetControlValue(targetElement);
-                    }
+            string colValue = actGrid.GetInputParamCalculatedValue(ActTableElement.Fields.WhereColumnValue);
 
-                    if (value.Equals(controlValue))
+            switch (actGrid.WhereOperator)
+            {
+                case ActTableElement.eRunColOperator.Equals:
+                    
+                    for (int i = 0; i < AECollection.Length; i++)
                     {
-                        return i;
+                        if (colValue.Equals(GetControlValueForComparision(actGrid, AECollection[i])))
+                        {
+                            return i;
+                        }
                     }
-                }
+                    break;
+
+                case ActTableElement.eRunColOperator.NotEquals:
+                    for (int i = 0; i < AECollection.Length; i++)
+                    {
+                        if (!colValue.Equals(GetControlValueForComparision(actGrid, AECollection[i])))
+                        {
+                            return i;
+                        }
+                    }
+                    break;
+
+                case ActTableElement.eRunColOperator.Contains:
+                    for (int i = 0; i < AECollection.Length; i++)
+                    {
+                        if (colValue.Contains(GetControlValueForComparision(actGrid, AECollection[i])))
+                        {
+                            return i;
+                        }
+                    }
+                    break;
+
+                case ActTableElement.eRunColOperator.NotContains:
+                    for (int i = 0; i < AECollection.Length; i++)
+                    {
+                        if (!colValue.Contains(GetControlValueForComparision(actGrid, AECollection[i])))
+                        {
+                            return i;
+                        }
+                    }
+                    break;
+
+                case ActTableElement.eRunColOperator.StartsWith:
+                    for (int i = 0; i < AECollection.Length; i++)
+                    {
+                        if (colValue.StartsWith(GetControlValueForComparision(actGrid, AECollection[i])))
+                        {
+                            return i;
+                        }
+                    }
+                    break;
+
+                case ActTableElement.eRunColOperator.NotStartsWith:
+                    for (int i = 0; i < AECollection.Length; i++)
+                    {
+                        if (!colValue.StartsWith(GetControlValueForComparision(actGrid, AECollection[i])))
+                        {
+                            return i;
+                        }
+                    }
+                    break;
+
+                case ActTableElement.eRunColOperator.EndsWith:
+                    for (int i = 0; i < AECollection.Length; i++)
+                    {
+                        if (colValue.EndsWith(GetControlValueForComparision(actGrid, AECollection[i])))
+                        {
+                            return i;
+                        }
+                    }
+                    break;
+
+                case ActTableElement.eRunColOperator.NotEndsWith:
+                    for (int i = 0; i < AECollection.Length; i++)
+                    {
+                        if (!colValue.EndsWith(GetControlValueForComparision(actGrid, AECollection[i])))
+                        {
+                            return i;
+                        }
+                    }
+                    break;
+
+                default:
+                    throw new NotImplementedException("Selected operator " + actGrid.WhereOperator + " not implemented.");
             }
 
-            if (ActTableElement.eRunColOperator.Contains == WhereOperator)
-            {
-                for (int i = 0; i < AECollection.Length; i++)
-                {
-                    targetElement = AECollection[i];
-                    if (propVal == ActTableElement.eRunColPropertyValue.Text)
-                    {
-                        controlValue = GetControlText(targetElement);
-                    }
-                    else if (propVal == ActTableElement.eRunColPropertyValue.Value)
-                    {
-                        controlValue = GetControlValue(targetElement);
-                    }
+            throw new Exception("Grid Cell matching to given condition not present.");
+        }
 
-                    if (controlValue.Contains(value))
-                    {
-                        return i;
-                    }
-                }
+        private string GetControlValueForComparision(ActTableElement actGrid, UIAuto.AutomationElement targetElement)
+        {
+            if (actGrid.WhereProperty == ActTableElement.eRunColPropertyValue.Text)
+            {
+                return GetControlText(targetElement);
+            }
+            else if (actGrid.WhereProperty == ActTableElement.eRunColPropertyValue.Value)
+            {
+                return GetControlValue(targetElement);
             }
 
-            throw new Exception("Given Row Value " + value + " is not present in Grid");
+            return string.Empty;
         }
 
         public Dictionary<string, UIAuto.AutomationElement[]> GetUpdateDictionary(UIAuto.AutomationElement AE, ref bool isElementsFromPoints)
@@ -5465,7 +5524,7 @@ namespace GingerCore.Drivers
                             if (!isElementsFromPoints)
                             {
                                 AEWhereColl = GetColumnCollection(actGrid.WhereColSelector, actGrid.WhereColumnTitle, AE);
-                                RowNumber = GetRowNumFromCollection(AEWhereColl, actGrid.WhereProperty, actGrid.WhereOperator, actGrid.GetInputParamCalculatedValue(ActTableElement.Fields.WhereColumnValue));
+                                RowNumber = GetMatchingRowNumFromCollection(AEWhereColl, actGrid);
                             }
                             else
                             {


### PR DESCRIPTION
Implemented Missing Where operators for Table Element Action in Power Builder.
Below operators were not implemented

NotEquals,
NotContains,
StartsWith,
NotStartsWith,
EndsWith,
NotEndsWith

Thank you for your contribution.
Before submitting this PR, please make sure:

- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve all Codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Update the Help Library document to match any feature changes
