### PR TITLE
Fixed fall-back mechanism if the ffmpeg is not downloaded

### DIFF
--- a/Ginger/Ginger/Drivers/DriversConfigsEditPages/WebAgentConfigEditPage.xaml.cs
+++ b/Ginger/Ginger/Drivers/DriversConfigsEditPages/WebAgentConfigEditPage.xaml.cs
@@ -78,7 +78,7 @@ namespace Ginger.Drivers.DriversConfigsEditPages
 
             if (string.IsNullOrEmpty(xRecordVideoDirVE.ValueTextBox.Text))
             {
-                xRecordVideoDirVE.ValueTextBox.Text = @"~\Documents\VideoRecordings";
+                xRecordVideoDirVE.ValueTextBox.Text = @"~\\Documents\VideoRecordings";
                 return;
             }
 

--- a/Ginger/GingerCoreNET/Drivers/CoreDrivers/Web/Playwright/PlaywrightDriver.cs
+++ b/Ginger/GingerCoreNET/Drivers/CoreDrivers/Web/Playwright/PlaywrightDriver.cs
@@ -111,19 +111,26 @@ namespace Amdocs.Ginger.CoreNET.Drivers.CoreDrivers.Web.Playwright
 
         private PlaywrightBrowser.Options BuildPlaywrightBrowserOptions()
         {
-            string recordVideoDir = RecordVideoDir;
-            if (recordVideoDir != null && recordVideoDir.StartsWith(@"~\"))
+            string recordVideoDir = null;
+            RecordVideoSize? recordVideoSize = null;
+
+            if (WorkSpace.Instance.IsRunningFromRunsetOrCLI() && EnableVideoRecording)
             {
-                string solutionFolder = amdocs.ginger.GingerCoreNET.WorkSpace.Instance.Solution.Folder;
-                recordVideoDir = recordVideoDir.Replace(@"~\", solutionFolder, StringComparison.InvariantCultureIgnoreCase);
+                Reporter.ToLog(eLogLevel.DEBUG, "Execution happening through CLI/Runset");
+
+                recordVideoDir = RecordVideoDir;
+                if (recordVideoDir != null && recordVideoDir.StartsWith(@"~\"))
+                {
+                    string solutionFolder = amdocs.ginger.GingerCoreNET.WorkSpace.Instance.Solution.Folder;
+                    recordVideoDir = recordVideoDir.Replace(@"~\", solutionFolder, StringComparison.InvariantCultureIgnoreCase);
+                }
+
+                if (VideoHeight > 0 && VideoWidth > 0)
+                {
+                    recordVideoSize = new RecordVideoSize { Height = VideoHeight, Width = VideoWidth };
+                }
             }
 
-            RecordVideoSize? recordVideoSize = null;
-            if (VideoHeight > 0 && VideoWidth > 0)
-            {
-                recordVideoSize = new RecordVideoSize { Height = VideoHeight, Width = VideoWidth };
-            }
-            
             PlaywrightBrowser.Options options = new()
             {
                 Args = new[] { "--start-maximized" },
@@ -653,7 +660,7 @@ namespace Amdocs.Ginger.CoreNET.Drivers.CoreDrivers.Web.Playwright
         }
 
         [UserConfigured]
-        [UserConfiguredDefault(@"~\Documents\VideoRecordings")]
+        [UserConfiguredDefault(@"~\\Documents\VideoRecordings")]
         [UserConfiguredDescription("Set directory path for storing the recorded video of browser actions being performed in ongoing session.")]
         public string? RecordVideoDir { get; set; }
 

--- a/Ginger/GingerCoreNET/Drivers/CoreDrivers/Web/Playwright/PlaywrightPersistentBrowser.cs
+++ b/Ginger/GingerCoreNET/Drivers/CoreDrivers/Web/Playwright/PlaywrightPersistentBrowser.cs
@@ -128,8 +128,8 @@ namespace Amdocs.Ginger.CoreNET.Drivers.CoreDrivers.Web.Playwright
                 return null;
             }
 
-            RecordVideoSize recordVideoSize = new RecordVideoSize { Height = -1, Width = -1 };
-            var recordVideoDir = string.Empty;
+            RecordVideoSize recordVideoSize = null;
+            string recordVideoDir = null;
 
             if (_options != null && _options.EnableVideoRecording)
             {

--- a/Ginger/GingerCoreNET/WorkSpaceLib/WorkSpace.cs
+++ b/Ginger/GingerCoreNET/WorkSpaceLib/WorkSpace.cs
@@ -585,6 +585,11 @@ namespace amdocs.ginger.GingerCoreNET
             }
         }
 
+        public bool IsRunningFromRunsetOrCLI()
+        {
+            return WorkSpace.Instance.RunningInExecutionMode == true
+                || (WorkSpace.Instance.RunsetExecutor.RunSetConfig != null && WorkSpace.Instance.RunsetExecutor.RunSetConfig.ExecutionID != null);
+        }
 
         private static void HandleSolutionLoadSourceControl(Solution solution)
         {


### PR DESCRIPTION
1. Fixed fall-back mechanism if the ffmpeg is not downloaded
2. Added Logic to ensure the video recording is enabled only when execution happen through CLI or Runset level
3. handled some bugs as well

Thank you for your contribution.
Before submitting this PR, please make sure:

- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve all Codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Update the Help Library document to match any feature changes
