### PR TITLE
Fix null handling in GetTempFolderPathForRepo

### DIFF
--- a/Ginger/GingerCoreNET/RunLib/CLILib/CLIHelper.cs
+++ b/Ginger/GingerCoreNET/RunLib/CLILib/CLIHelper.cs
@@ -1067,6 +1067,8 @@ namespace Amdocs.Ginger.CoreNET.RunLib.CLILib
             string repoName = string.Empty;
             try
             {
+                sourceControlUrl = sourceControlUrl ?? this.SourceControlURL;
+
                 if (!string.IsNullOrEmpty(sourceControlUrl))
                 {
                     // Remove trailing slash if present


### PR DESCRIPTION
Updated the `GetTempFolderPathForRepo` method in `CLIHelper.cs` to include a null-coalescing assignment for the `sourceControlUrl` parameter. If `sourceControlUrl` is null, it now defaults to `this.SourceControlURL`. Added a check to ensure `sourceControlUrl` is not null or empty before further processing.

Thank you for your contribution.
Before submitting this PR, please make sure:

- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve all Codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Update the Help Library document to match any feature changes
