### PR TITLE
External Configuration Pages Current Entity Saved items Issue fixed

### DIFF
--- a/Ginger/Ginger/ExternalConfigurations/AskLisaConfigurationsPage.xaml.cs
+++ b/Ginger/Ginger/ExternalConfigurations/AskLisaConfigurationsPage.xaml.cs
@@ -44,6 +44,7 @@ namespace Ginger.Configurations
             userConfig = WorkSpace.Instance.Solution.AskLisaConfiguration;
 
             userConfig.StartDirtyTracking();
+            WorkSpace.Instance.CurrentSelectedItem = userConfig;
             SetControls();
 
         }

--- a/Ginger/Ginger/ExternalConfigurations/GingerOpsConfigurationPage.xaml.cs
+++ b/Ginger/Ginger/ExternalConfigurations/GingerOpsConfigurationPage.xaml.cs
@@ -45,6 +45,7 @@ namespace Ginger.ExternalConfigurations
             OpsAPI = new GingerOpsAPI();
             gingerOpsUserConfig = WorkSpace.Instance.SolutionRepository.GetAllRepositoryItems<GingerOpsConfiguration>().Count == 0 ? new GingerOpsConfiguration() : WorkSpace.Instance.SolutionRepository.GetFirstRepositoryItem<GingerOpsConfiguration>();
             gingerOpsUserConfig.StartDirtyTracking();
+            WorkSpace.Instance.CurrentSelectedItem = gingerOpsUserConfig;
             SetControls();
 
         }

--- a/Ginger/Ginger/ExternalConfigurations/GingerPlayConfigurationpage.xaml.cs
+++ b/Ginger/Ginger/ExternalConfigurations/GingerPlayConfigurationpage.xaml.cs
@@ -50,6 +50,7 @@ namespace Ginger.ExternalConfigurations
             GingerCoreNET.GeneralLib.General.CreateGingerPlayConfiguration();
             gingerPlayConfiguration = WorkSpace.Instance.SolutionRepository.GetAllRepositoryItems<GingerPlayConfiguration>().Count == 0 ? new GingerPlayConfiguration() : WorkSpace.Instance.SolutionRepository.GetFirstRepositoryItem<GingerPlayConfiguration>();
             gingerPlayConfiguration.StartDirtyTracking();
+            WorkSpace.Instance.CurrentSelectedItem = gingerPlayConfiguration;
             SetControls();
         }
 

--- a/Ginger/Ginger/ExternalConfigurations/WireMockConfigurationPage.xaml.cs
+++ b/Ginger/Ginger/ExternalConfigurations/WireMockConfigurationPage.xaml.cs
@@ -44,6 +44,7 @@ namespace Ginger.ExternalConfigurations
         {
             wireMockConfiguration = WorkSpace.Instance.SolutionRepository.GetAllRepositoryItems<WireMockConfiguration>().Count == 0 ? new WireMockConfiguration() : WorkSpace.Instance.SolutionRepository.GetFirstRepositoryItem<WireMockConfiguration>();
             wireMockConfiguration.StartDirtyTracking();
+            WorkSpace.Instance.CurrentSelectedItem = wireMockConfiguration;
             mockAPI = new WireMockAPI();
             SetControls();
         }

--- a/Ginger/Ginger/ExternalConfigurations/ZAPConfigurationPage.xaml.cs
+++ b/Ginger/Ginger/ExternalConfigurations/ZAPConfigurationPage.xaml.cs
@@ -45,6 +45,7 @@ namespace Ginger.ExternalConfigurations
             zAPConfiguration = WorkSpace.Instance.SolutionRepository.GetAllRepositoryItems<ZAPConfiguration>().Count == 0 ? new ZAPConfiguration() : WorkSpace.Instance.SolutionRepository.GetFirstRepositoryItem<ZAPConfiguration>();
             SetControls();
             zAPConfiguration.StartDirtyTracking();
+            WorkSpace.Instance.CurrentSelectedItem = zAPConfiguration;
 
         }
 

--- a/Ginger/Ginger/ExternalConfigurations/ZAPConfigurationPage.xaml.cs
+++ b/Ginger/Ginger/ExternalConfigurations/ZAPConfigurationPage.xaml.cs
@@ -43,10 +43,9 @@ namespace Ginger.ExternalConfigurations
         private void Init()
         {
             zAPConfiguration = WorkSpace.Instance.SolutionRepository.GetAllRepositoryItems<ZAPConfiguration>().Count == 0 ? new ZAPConfiguration() : WorkSpace.Instance.SolutionRepository.GetFirstRepositoryItem<ZAPConfiguration>();
-            SetControls();
             zAPConfiguration.StartDirtyTracking();
             WorkSpace.Instance.CurrentSelectedItem = zAPConfiguration;
-
+            SetControls();
         }
 
         private void SetControls()


### PR DESCRIPTION
Thank you for your contribution.
Before submitting this PR, please make sure:

- [ ] PR description and commit message should describe the changes done in this PR
- [ ] Verify the PR is pointing to correct branch i.e. Release or Beta branch if the code fix is for specific release , else point it to master
- [ ] Latest Code from master or specific release branch is merged to your branch
- [ ] No unwanted\commented\junk code is included
- [ ] No new warning upon build solution
- [ ] Code Summary\Comments are added to my code which explains what my code is doing
- [ ] Existing unit test cases are passed
- [ ] New Unit tests are added for your development
- [ ] Sanity Tests are successfully executed for New and Existing Functionality
- [ ] Verify that changes are compatible with all relevant browsers and platforms.
- [ ] After creating pull request there should not be any conflicts
- [ ] Resolve all Codacy comments
- [ ] Builds and checks are passed before PR is sent for review
- [ ] Resolve code review comments
- [ ] Update the Help Library document to match any feature changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Opened configuration pages (AskLisa, GingerOps, GingerPlay, WireMock, ZAP) now correctly select and focus the loaded item in the workspace.
  * Toolbars and actions reliably operate on the intended configuration immediately after opening.
  * Provides a consistent UI context and reduces confusion when switching between configuration pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->