### PR TITLE
Fix in WebReportGenerator

### DIFF
--- a/Ginger/GingerCoreNET/Logger/WebReportGenerator.cs
+++ b/Ginger/GingerCoreNET/Logger/WebReportGenerator.cs
@@ -189,38 +189,38 @@ namespace Amdocs.Ginger.CoreNET.Logger
             try
             {
                 string backDir = System.IO.Directory.GetParent(clientAppFolderPath).FullName;
-                string viewReportTemplatePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Reports", "HTMLTemplates", "viewreport.html");
-                string strViewReport = System.IO.File.ReadAllText(viewReportTemplatePath);
-                strViewReport = strViewReport.Replace("<!--FULLREPORTPATH-->", Path.GetFileName(clientAppFolderPath));
-                System.IO.File.WriteAllText(Path.Combine(backDir, "viewreport.html"), strViewReport);
-                json = $"window.runsetData={json};";
+                if (IsSafeDirectoryToOpen(backDir))
+                {
+                    string viewReportTemplatePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Reports", "HTMLTemplates", "viewreport.html");
+                    string strViewReport = System.IO.File.ReadAllText(viewReportTemplatePath);
+                    strViewReport = strViewReport.Replace("<!--FULLREPORTPATH-->", Path.GetFileName(clientAppFolderPath));
+                    System.IO.File.WriteAllText(Path.Combine(backDir, "viewreport.html"), strViewReport);
+                    json = $"window.runsetData={json};";
 
 #warning Report Fix MEN not stable approach 
-                StringBuilder pageDataSb = new StringBuilder();
-                pageDataSb.Append("file:///");
-                pageDataSb.Append(backDir.Replace('\\', '/'));
-                pageDataSb.Append("/");
-                pageDataSb.Append("viewreport.html");
-                if (openObject != null)
-                {
-                    pageDataSb.Append("#/?Routed_Guid=");
-                    pageDataSb.Append(openObject.Guid);
-                }
-                string taskCommand = $"\"{pageDataSb}\"";
-                System.IO.File.WriteAllText(Path.Combine(clientAppFolderPath, "assets", "Execution_Data", "executiondata.js"), json);
+                    StringBuilder reportLocalUrl = new StringBuilder();
+                    reportLocalUrl.Append("file:///");
+                    reportLocalUrl.Append(backDir.Replace('\\', '/'));
+                    reportLocalUrl.Append("/");
+                    reportLocalUrl.Append("viewreport.html");
+                    if (openObject != null)
+                    {
+                        reportLocalUrl.Append("#/?Routed_Guid=");
+                        reportLocalUrl.Append(openObject.Guid);
+                    }
+                    string taskCommand = $"\"{reportLocalUrl}\"";
+                    System.IO.File.WriteAllText(Path.Combine(clientAppFolderPath, "assets", "Execution_Data", "executiondata.js"), json);
 
-                if (shouldDisplayReport && !Assembly.GetEntryAssembly().FullName.ToUpper().Contains("CONSOLE"))
-                {
-                    if (IsSafeDirectoryToOpen(backDir))
+                    if (shouldDisplayReport && !Assembly.GetEntryAssembly().FullName.ToUpper().Contains("CONSOLE"))
                     {
                         System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo() { FileName = @browserPath, Arguments = taskCommand, UseShellExecute = true });
                         System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo() { FileName = backDir, UseShellExecute = true });
                         response = true;
                     }
-                    else
-                    {
-                        Reporter.ToLog(eLogLevel.WARN, $"The report directory '{backDir}' is not considered safe to open automatically.");
-                    }
+                }
+                else
+                {
+                    Reporter.ToLog(eLogLevel.WARN, $"The report directory '{backDir}' is not considered safe to open automatically.");
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Description
<!-- Briefly describe your changes -->

## Type of Change
- [ ] Bug fix - [ ] New feature - [ ] Breaking change - [ ] Plugin update

## Checklist
- [ ] PR description clearly describes the changes
- [ ] Target branch is correct (master for features, Releases/* for fixes)
- [ ] Latest code from target branch merged
- [ ] No commented/junk code included
- [ ] No new build warnings or errors
- [ ] All existing unit tests pass
- [ ] New unit tests added for new functionality
- [ ] Cross-platform compatibility verified (Windows/Linux/macOS)
- [ ] CI/CD pipeline passes
- [ ] Code follows project conventions (Act{Platform}{Type}, {Platform}Driver)
- [ ] Repository objects use `[IsSerializedForLocalRepository]` where needed
- [ ] Error handling uses `Reporter.ToLog()` pattern
- [ ] Documentation updated for user-facing changes
- [ ] Self-review completed and code review comments addressed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reports are only auto-opened when located inside the designated Reports root; out-of-area reports now stay closed and emit a warning.
* **Improvements**
  * Launching Java-based workflows now validates Java paths per OS, detects Java version more reliably, and surfaces clearer error messages when launch fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->