### PR TITLE
Refactor MySQL connection string assignment logic

### DIFF
--- a/Ginger/GingerCoreNET/Database/DatabaseOperations.cs
+++ b/Ginger/GingerCoreNET/Database/DatabaseOperations.cs
@@ -489,11 +489,14 @@ namespace GingerCore.Environments
                             Password = EncryptionHandler.DecryptwithKey(PassCalculated)
                         };
                         if (port1.HasValue) my.Port = port1.Value;
-                        Database.ConnectionString = my.ConnectionString;
+                        if (string.IsNullOrEmpty(ConnectionStringCalculated))
+                        {
+                            Database.ConnectionString = my.ConnectionString;
+                        }
 
                         oConn = new MySqlConnection
                         {
-                            ConnectionString = my.ConnectionString
+                            ConnectionString = GetConnectionString()
                         };
                         oConn.Open();
                         break;


### PR DESCRIPTION
Check if ConnectionStringCalculated is empty before assigning my.ConnectionString to Database.ConnectionString. Use GetConnectionString() when initializing MySqlConnection to ensure the correct connection string is used.

## Description
<!-- Briefly describe your changes -->

## Type of Change
- [ ] Bug fix - [ ] New feature - [ ] Breaking change - [ ] Plugin update

## Checklist
- [ ] PR description clearly describes the changes
- [ ] Target branch is correct (master for features, Releases/* for fixes)
- [ ] Latest code from target branch merged
- [ ] No commented/junk code included
- [ ] No new build warnings or errors
- [ ] All existing unit tests pass
- [ ] New unit tests added for new functionality
- [ ] Cross-platform compatibility verified (Windows/Linux/macOS)
- [ ] CI/CD pipeline passes
- [ ] Code follows project conventions (Act{Platform}{Type}, {Platform}Driver)
- [ ] Repository objects use `[IsSerializedForLocalRepository]` where needed
- [ ] Error handling uses `Reporter.ToLog()` pattern
- [ ] Documentation updated for user-facing changes
- [ ] Self-review completed and code review comments addressed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL database connection handling to prevent unintended connection string overwrites and ensure proper connection initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->