### PR TITLE
Parse SslMode from connection string for MySQL

### DIFF
--- a/Ginger/GingerCoreNET/Database/DatabaseOperations.cs
+++ b/Ginger/GingerCoreNET/Database/DatabaseOperations.cs
@@ -489,7 +489,34 @@ namespace GingerCore.Environments
                             Password = EncryptionHandler.DecryptwithKey(PassCalculated)
                         };
                         if (port1.HasValue) my.Port = port1.Value;
-                        Database.ConnectionString = my.ConnectionString;
+                        if (!string.IsNullOrEmpty(ConnectionStringCalculated))
+                        {
+                            foreach (string segment in ConnectionStringCalculated.Split(';', StringSplitOptions.RemoveEmptyEntries))
+                            {
+                                int eq = segment.IndexOf('=');
+                                if (eq <= 0)
+                                {
+                                    continue;
+                                }
+
+                                string key = segment.Substring(0, eq).Trim();
+                                if (key.Equals("SslMode", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    string value = segment.Substring(eq + 1).Trim();
+                                    if (Enum.TryParse(value, ignoreCase: true, out MySqlSslMode sslMode))
+                                    {
+                                        my.SslMode = sslMode;
+                                    }
+
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (string.IsNullOrEmpty(ConnectionStringCalculated))
+                        {
+                            Database.ConnectionString = my.ConnectionString;
+                        }
 
                         oConn = new MySqlConnection
                         {


### PR DESCRIPTION
Add logic to extract and set the SslMode property from the calculated connection string if present. Only assign Database.ConnectionString if the calculated string is empty. This improves MySQL connection configuration flexibility.

## Description
<!-- Briefly describe your changes -->

## Type of Change
- [ ] Bug fix - [ ] New feature - [ ] Breaking change - [ ] Plugin update

## Checklist
- [ ] PR description clearly describes the changes
- [ ] Target branch is correct (master for features, Releases/* for fixes)
- [ ] Latest code from target branch merged
- [ ] No commented/junk code included
- [ ] No new build warnings or errors
- [ ] All existing unit tests pass
- [ ] New unit tests added for new functionality
- [ ] Cross-platform compatibility verified (Windows/Linux/macOS)
- [ ] CI/CD pipeline passes
- [ ] Code follows project conventions (Act{Platform}{Type}, {Platform}Driver)
- [ ] Repository objects use `[IsSerializedForLocalRepository]` where needed
- [ ] Error handling uses `Reporter.ToLog()` pattern
- [ ] Documentation updated for user-facing changes
- [ ] Self-review completed and code review comments addressed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL database connection handling to properly respect SSL/TLS configuration settings, ensuring more reliable and secure encrypted database connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->