### PR TITLE
CloseAllRunningPluginProcesses When the Standalone BF is Executed or …

### DIFF
--- a/Ginger/GingerCoreNET/Run/GingerExecutionEngine.cs
+++ b/Ginger/GingerCoreNET/Run/GingerExecutionEngine.cs
@@ -4515,6 +4515,7 @@ namespace Ginger.Run
 
                 if (standaloneExecution)
                 {
+                    WorkSpace.Instance.PlugInsManager.CloseAllRunningPluginProcesses();
                     IsRunning = false;
                     Status = RunsetStatus;
                 }

--- a/Ginger/GingerCoreNET/Run/RunsetExecutor.cs
+++ b/Ginger/GingerCoreNET/Run/RunsetExecutor.cs
@@ -730,6 +730,7 @@ namespace Ginger.Run
                 Reporter.ToLog(eLogLevel.INFO, string.Format("######## Doing {0} Execution Cleanup", GingerDicser.GetTermResValue(eTermResKey.RunSet)));
                 //CloseAllAgents();
                 CloseAllEnvironments();
+                WorkSpace.Instance.PlugInsManager.CloseAllRunningPluginProcesses();
                 Reporter.ToLog(eLogLevel.INFO, string.Format("########################## {0} Execution Ended", GingerDicser.GetTermResValue(eTermResKey.RunSet)));
             }
             catch (Exception ex)


### PR DESCRIPTION
…At RunsetExecutionEnd

## Description
<!-- Briefly describe your changes -->

## Type of Change
- [ ] Bug fix - [ ] New feature - [ ] Breaking change - [ ] Plugin update

## Checklist
- [ ] PR description clearly describes the changes
- [ ] Target branch is correct (master for features, Releases/* for fixes)
- [ ] Latest code from target branch merged
- [ ] No commented/junk code included
- [ ] No new build warnings or errors
- [ ] All existing unit tests pass
- [ ] New unit tests added for new functionality
- [ ] Cross-platform compatibility verified (Windows/Linux/macOS)
- [ ] CI/CD pipeline passes
- [ ] Code follows project conventions (Act{Platform}{Type}, {Platform}Driver)
- [ ] Repository objects use `[IsSerializedForLocalRepository]` where needed
- [ ] Error handling uses `Reporter.ToLog()` pattern
- [ ] Documentation updated for user-facing changes
- [ ] Self-review completed and code review comments addressed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin processes are now properly closed when execution sequences end, improving resource cleanup and preventing process leaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ginger-Automation/Ginger/pull/4494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->